### PR TITLE
Initial implementation of d2l-search-facets

### DIFF
--- a/all-imports.html
+++ b/all-imports.html
@@ -1,3 +1,6 @@
+<link rel="import" href="d2l-search-facets-grouping.html">
+<link rel="import" href="d2l-search-facets-option.html">
+<link rel="import" href="d2l-search-facets.html">
 <link rel="import" href="d2l-search-results-count.html">
 <link rel="import" href="d2l-sort-by-dropdown-option.html">
 <link rel="import" href="d2l-sort-by-dropdown.html">

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^2.0.0",
+    "d2l-colors": "^3.1.2",
     "d2l-dropdown": "^6.6.2",
     "d2l-icons": "^5.1.2",
     "d2l-inputs": "^1.0.2",

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "polymer": "Polymer/polymer#^2.0.0",
     "d2l-dropdown": "^6.6.2",
     "d2l-icons": "^5.1.2",
+    "d2l-inputs": "^1.0.2",
     "d2l-localize-behavior": "^1.1.3",
     "d2l-menu": "^1.2.0"
   },

--- a/d2l-search-facets-grouping.html
+++ b/d2l-search-facets-grouping.html
@@ -137,25 +137,12 @@
 					this._boundListeners._onFacetOptionChange);
 			}
 
-			_getEffectiveChildren() {
-				return Polymer.FlattenedNodesObserver.getFlattenedNodes(this)
-					.filter(function(n) { return n.nodeType === Node.ELEMENT_NODE; });
-			}
-
 			_onFacetOptionChange(e) {
-				e.detail.checked
-					? this._optionsSelected.push(e.detail.value)
-					: this._optionsSelected.splice(this._optionsSelected.indexOf(e.detail.value), 1);
-
-				this.dispatchEvent(new CustomEvent(
-					'd2l-search-facets-grouping-change', {
-						bubbles: true, composed: true, detail:
-						{
-							grouping: this.value,
-							selected: this._optionsSelected,
-						}
-					}
-				));
+				this.dispatchEvent(new CustomEvent('d2l-search-facets-grouping-change', {
+					bubbles: true,
+					composed: true,
+					detail: Object.assign({}, e.detail, { grouping: this.value })
+				}));
 			}
 
 			_hideOptions() {

--- a/d2l-search-facets-grouping.html
+++ b/d2l-search-facets-grouping.html
@@ -49,6 +49,17 @@
 			static get properties() {
 				return {
 					/**
+					* Reference to bound listener functions to be removed in disconnectedCallback
+					*/
+					_boundListeners: {
+						type: Object,
+						value: function() {
+							return {
+								_onFacetOptionChange: null,
+							};
+						}
+					},
+					/**
 					* List of <d2l-search-facets-option> elements
 					*/
 					_optionElements: {
@@ -70,62 +81,83 @@
 						value: false,
 					},
 					/**
-					* Label of the grouping
+					* Number of facet options initially displayed. All options are shown by default
 					*/
-					label: {
+					hideAfter: {
+						type: Number,
+					},
+					/**
+					* The name of the grouping
+					*/
+					text: {
 						type: String,
 						value: '',
 					},
 					/**
-					* Number of facet options initially displayed. All options are shown by default
+					* The value of the grouping name
 					*/
-					initiallyShown: {
-						type: Number,
-					}
+					value: {
+						type: String,
+						value: '',
+					},
 				};
 			}
 
 			connectedCallback() {
 				super.connectedCallback();
-				this.addEventListener('d2l-search-facets-option-change', function(e) {
-					e.detail.checked
-						? this._optionsSelected.push(e.detail.option)
-						: this._optionsSelected.splice(this._optionsSelected.indexOf(e.detail.option), 1);
-
-					this.dispatchEvent(new CustomEvent(
-						'd2l-search-facets-grouping-change', {
-							bubbles: true, composed: true, detail:
-							{
-								grouping: this.label,
-								selected: this._optionsSelected,
-							}
-						}
-					));
-				}.bind(this));
-
-				// Child elements may not be rendered if this is a <dom-repeat>. Wait for next
-				// render to query for them
 				Polymer.RenderStatus.afterNextRender(this, function() {
-					this._optionElements = Polymer.FlattenedNodesObserver.getFlattenedNodes(this)
-						.filter(function(n) { return n.nodeType === Node.ELEMENT_NODE; });
+					// Child elements may not be rendered if this is a <dom-repeat>. Wait for next
+					// render to query for them
+					this._boundListeners._onFacetOptionChange = this._onFacetOptionChange.bind(this);
 
-					if (!this.initiallyShown) {
-						this.initiallyShown = this._optionElements.length;
+					this.addEventListener('d2l-search-facets-option-change',
+						this._boundListeners._onFacetOptionChange);
+
+					if (!this.hideAfter) {
+						this.hideAfter = this._getOptionElements().length;
 					}
 
-					this._showMoreButtonVisible = this.initiallyShown < this._optionElements.length;
+					this._showMoreButtonVisible = this.hideAfter < this._getOptionElements().length;
 					this._updateOptionVisibility('none');
 				}.bind(this));
 			}
 
+			disconnectedCallback() {
+				super.disconnectedCallback();
+				this.removeEventListener('d2l-search-facets-option-change',
+					this._boundListeners._onFacetOptionChange);
+			}
+
+			_getOptionElements() {
+				return Polymer.FlattenedNodesObserver.getFlattenedNodes(this)
+					.filter(function(n) { return n.nodeType === Node.ELEMENT_NODE; });
+			}
+
+			_onFacetOptionChange(e) {
+				e.detail.checked
+					? this._optionsSelected.push(e.detail.value)
+					: this._optionsSelected.splice(this._optionsSelected.indexOf(e.detail.value), 1);
+
+				this.dispatchEvent(new CustomEvent(
+					'd2l-search-facets-grouping-change', {
+						bubbles: true, composed: true, detail:
+						{
+							grouping: this.value,
+							selected: this._optionsSelected,
+						}
+					}
+				));
+			}
+
 			_showMore() {
-				this._updateOptionVisibility('inline-block');
+				this._updateOptionVisibility('block');
 				this._showMoreButtonVisible = false;
 			}
 
 			_updateOptionVisibility(display) {
-				for (let index = this.initiallyShown; index < this._optionElements.length; index++) {
-					this._optionElements[index].style.display = display;
+				const optionElements = this._getOptionElements();
+				for (let index = this.hideAfter; index < optionElements.length; index++) {
+					optionElements[index].style.display = display;
 				}
 			}
 

--- a/d2l-search-facets-grouping.html
+++ b/d2l-search-facets-grouping.html
@@ -42,9 +42,9 @@
 		<fieldset class="d2l-search-facets-grouping-fieldset">
 			<legend class="d2l-search-facets-grouping-legend">[[text]]</legend>
 			<slot></slot>
-			<template is="dom-if" if="[[_showMoreButtonVisible]]">
+			<template is="dom-if" if="[[_showOptionsButtonVisible]]">
 				<d2l-input-checkbox-spacer class="d2l-search-facets-grouping-show-more">
-					<button on-click="_showMore">More</button>
+					<button on-click="_showOptions">More</button>
 				</d2l-input-checkbox-spacer>
 			</template>
 		</fieldset>
@@ -70,11 +70,11 @@
 						}
 					},
 					/**
-					* List of <d2l-search-facets-option> elements
+					* Reference to the style element created to hide options. Deleted when
+					* the show options button is clicked
 					*/
-					_optionElements: {
-						type: Array,
-						value: function() { return []; },
+					_hideOptionsStyleElement: {
+						type: HTMLElement,
 					},
 					/**
 					* List of selected options (e.g., ['optionA', ...]s)
@@ -84,14 +84,15 @@
 						value: function() { return []; },
 					},
 					/**
-					* Visibility of 'More' button - true if initiallyShown < _optionElements.length
+					* Visibility of 'More' button, true if hideAfter is present
 					*/
-					_showMoreButtonVisible: {
+					_showOptionsButtonVisible: {
 						type: Boolean,
 						value: false,
 					},
 					/**
-					* Number of facet options initially displayed. All options are shown by default
+					* Number of facet options initially displayed. All options are shown by default.
+					* Should not be greater than the number of child elements
 					*/
 					hideAfter: {
 						type: Number,
@@ -115,20 +116,18 @@
 
 			connectedCallback() {
 				super.connectedCallback();
+
+				if (this.hideAfter) {
+					this._hideOptions();
+					this._showOptionsButtonVisible = true;
+				}
+
 				Polymer.RenderStatus.afterNextRender(this, function() {
-					// Child elements may not be rendered if this is a <dom-repeat>. Wait for next
-					// render to query for them
 					this._boundListeners._onFacetOptionChange = this._onFacetOptionChange.bind(this);
 
 					this.addEventListener('d2l-search-facets-option-change',
 						this._boundListeners._onFacetOptionChange);
 
-					if (!this.hideAfter) {
-						this.hideAfter = this._getOptionElements().length;
-					}
-
-					this._showMoreButtonVisible = this.hideAfter < this._getOptionElements().length;
-					this._updateOptionVisibility('none');
 				}.bind(this));
 			}
 
@@ -138,7 +137,7 @@
 					this._boundListeners._onFacetOptionChange);
 			}
 
-			_getOptionElements() {
+			_getEffectiveChildren() {
 				return Polymer.FlattenedNodesObserver.getFlattenedNodes(this)
 					.filter(function(n) { return n.nodeType === Node.ELEMENT_NODE; });
 			}
@@ -159,19 +158,24 @@
 				));
 			}
 
-			_showMore() {
-				this._updateOptionVisibility('block');
-				this._showMoreButtonVisible = false;
+			_hideOptions() {
+				const styleElement = document.createElement('style');
+				styleElement.type = 'text/css';
+				const hideOptionsCss = `.d2l-search-facets-grouping-fieldset ::slotted(d2l-search-facets-option:nth-child(n+${this.hideAfter + 1})) {
+					display: none
+				}`;
+				styleElement.appendChild(document.createTextNode(hideOptionsCss));
+				this._hideOptionsStyleElement = styleElement;
+
+				this.shadowRoot.appendChild(styleElement);
 			}
 
-			_updateOptionVisibility(display) {
-				const optionElements = this._getOptionElements();
-				for (let index = this.hideAfter; index < optionElements.length; index++) {
-					optionElements[index].style.display = display;
-				}
+			_showOptions() {
+				this.shadowRoot.removeChild(this._hideOptionsStyleElement);
+				this._showOptionsButtonVisible = false;
 			}
-
 		}
+
 		customElements.define(SearchFacetsGrouping.is, SearchFacetsGrouping);
 	</script>
 </dom-module>

--- a/d2l-search-facets-grouping.html
+++ b/d2l-search-facets-grouping.html
@@ -42,9 +42,9 @@
 		<fieldset class="d2l-search-facets-grouping-fieldset">
 			<legend class="d2l-search-facets-grouping-legend">[[text]]</legend>
 			<slot></slot>
-			<template is="dom-if" if="[[_showOptionsButtonVisible]]">
+			<template is="dom-if" if="[[hasMore]]">
 				<d2l-input-checkbox-spacer class="d2l-search-facets-grouping-show-more">
-					<button on-click="_showOptions">More</button>
+					<button on-click="_onMoreClicked">More</button>
 				</d2l-input-checkbox-spacer>
 			</template>
 		</fieldset>
@@ -70,32 +70,12 @@
 						}
 					},
 					/**
-					* Reference to the style element created to hide options. Deleted when
-					* the show options button is clicked
+					* Indicates whether this grouping has more options to be added later. Controls
+					* the visibility of the 'More' button
 					*/
-					_hideOptionsStyleElement: {
-						type: HTMLElement,
-					},
-					/**
-					* List of selected options (e.g., ['optionA', ...]s)
-					*/
-					_optionsSelected: {
-						type: Array,
-						value: function() { return []; },
-					},
-					/**
-					* Visibility of 'More' button, true if hideAfter is present
-					*/
-					_showOptionsButtonVisible: {
+					hasMore: {
 						type: Boolean,
 						value: false,
-					},
-					/**
-					* Number of facet options initially displayed. All options are shown by default.
-					* Should not be greater than the number of child elements
-					*/
-					hideAfter: {
-						type: Number,
 					},
 					/**
 					* The name of the grouping
@@ -117,17 +97,11 @@
 			connectedCallback() {
 				super.connectedCallback();
 
-				if (this.hideAfter) {
-					this._hideOptions();
-					this._showOptionsButtonVisible = true;
-				}
-
 				Polymer.RenderStatus.afterNextRender(this, function() {
 					this._boundListeners._onFacetOptionChange = this._onFacetOptionChange.bind(this);
 
 					this.addEventListener('d2l-search-facets-option-change',
 						this._boundListeners._onFacetOptionChange);
-
 				}.bind(this));
 			}
 
@@ -145,21 +119,12 @@
 				}));
 			}
 
-			_hideOptions() {
-				const styleElement = document.createElement('style');
-				styleElement.type = 'text/css';
-				const hideOptionsCss = `.d2l-search-facets-grouping-fieldset ::slotted(d2l-search-facets-option:nth-child(n+${this.hideAfter + 1})) {
-					display: none
-				}`;
-				styleElement.appendChild(document.createTextNode(hideOptionsCss));
-				this._hideOptionsStyleElement = styleElement;
-
-				this.shadowRoot.appendChild(styleElement);
-			}
-
-			_showOptions() {
-				this.shadowRoot.removeChild(this._hideOptionsStyleElement);
-				this._showOptionsButtonVisible = false;
+			_onMoreClicked() {
+				this.dispatchEvent(new CustomEvent('d2l-search-facets-grouping-has-more', {
+					bubbles: true,
+					composed: true,
+					detail: { grouping: this.value }
+				}));
 			}
 		}
 

--- a/d2l-search-facets-grouping.html
+++ b/d2l-search-facets-grouping.html
@@ -1,17 +1,26 @@
 <link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="../d2l-inputs/d2l-input-checkbox-spacer.html">
 <link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
 
 <dom-module id="d2l-search-facets-grouping">
 	<template strip-whitespace>
 		<style>
 			:host {
-				display: flex;
-				flex-direction: column;
+				display: block;
 			}
-			.d2l-search-facets-grouping-label {
+
+			.d2l-search-facets-grouping-fieldset {
+				border: none;
+				margin: 0;
+				padding: 0;
+			}
+
+			.d2l-search-facets-grouping-legend {
 				@apply --d2l-body-compact-text;
 				font-weight: bold;
+				margin-bottom: 0.4rem;
+				padding: 0;
 			}
 
 			.d2l-search-facets-grouping-show-more > button {
@@ -20,7 +29,7 @@
 				color: var(--d2l-color-celestine);
 				font-family: inherit;
 				outline: none;
-				padding: 0px;
+				padding: 0;
 			}
 
 			.d2l-search-facets-grouping-show-more > button:hover,
@@ -30,14 +39,15 @@
 			}
 
 		</style>
-		<span class="d2l-search-facets-grouping-label">[[label]]</span>
-		<d2l-input-checkbox-spacer></d2l-input-checkbox-spacer>
-		<slot></slot>
-		<template is="dom-if" if="{{_showMoreButtonVisible}}">
-			<d2l-input-checkbox-spacer class="d2l-search-facets-grouping-show-more">
-				<button on-click="_showMore">More</button>
-			</d2l-input-checkbox-spacer>
-		</template>
+		<fieldset class="d2l-search-facets-grouping-fieldset">
+			<legend class="d2l-search-facets-grouping-legend">[[text]]</legend>
+			<slot></slot>
+			<template is="dom-if" if="[[_showMoreButtonVisible]]">
+				<d2l-input-checkbox-spacer class="d2l-search-facets-grouping-show-more">
+					<button on-click="_showMore">More</button>
+				</d2l-input-checkbox-spacer>
+			</template>
+		</fieldset>
 	</template>
 	<script>
 		/**

--- a/d2l-search-facets-grouping.html
+++ b/d2l-search-facets-grouping.html
@@ -1,0 +1,135 @@
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../d2l-inputs/d2l-input-checkbox-spacer.html">
+<link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
+
+<dom-module id="d2l-search-facets-grouping">
+	<template strip-whitespace>
+		<style>
+			:host {
+				display: flex;
+				flex-direction: column;
+			}
+			.d2l-search-facets-grouping-label {
+				@apply --d2l-body-compact-text;
+				font-weight: bold;
+			}
+
+			.d2l-search-facets-grouping-show-more > button {
+				@apply --d2l-body-compact-text;
+				border: none;
+				color: var(--d2l-color-celestine);
+				font-family: inherit;
+				outline: none;
+				padding: 0px;
+			}
+
+			.d2l-search-facets-grouping-show-more > button:hover,
+			.d2l-search-facets-grouping-show-more > button:focus {
+				cursor: pointer;
+				font-weight: bold;
+			}
+
+		</style>
+		<span class="d2l-search-facets-grouping-label">[[label]]</span>
+		<d2l-input-checkbox-spacer></d2l-input-checkbox-spacer>
+		<slot></slot>
+		<template is="dom-if" if="{{_showMoreButtonVisible}}">
+			<d2l-input-checkbox-spacer class="d2l-search-facets-grouping-show-more">
+				<button on-click="_showMore">More</button>
+			</d2l-input-checkbox-spacer>
+		</template>
+	</template>
+	<script>
+		/**
+		 * `<d2l-search-facets-grouping>`
+		 * A grouping of search facet options that keeps tracks of selected options
+		 */
+		class SearchFacetsGrouping extends Polymer.Element {
+			static get is() { return 'd2l-search-facets-grouping'; }
+			static get properties() {
+				return {
+					/**
+					* List of <d2l-search-facets-option> elements
+					*/
+					_optionElements: {
+						type: Array,
+						value: function() { return []; },
+					},
+					/**
+					* List of selected options (e.g., ['optionA', ...]s)
+					*/
+					_optionsSelected: {
+						type: Array,
+						value: function() { return []; },
+					},
+					/**
+					* Visibility of 'More' button - true if initiallyShown < _optionElements.length
+					*/
+					_showMoreButtonVisible: {
+						type: Boolean,
+						value: false,
+					},
+					/**
+					* Label of the grouping
+					*/
+					label: {
+						type: String,
+						value: '',
+					},
+					/**
+					* Number of facet options initially displayed. All options are shown by default
+					*/
+					initiallyShown: {
+						type: Number,
+					}
+				};
+			}
+
+			connectedCallback() {
+				super.connectedCallback();
+				this.addEventListener('d2l-search-facets-option-change', function(e) {
+					e.detail.checked
+						? this._optionsSelected.push(e.detail.option)
+						: this._optionsSelected.splice(this._optionsSelected.indexOf(e.detail.option), 1);
+
+					this.dispatchEvent(new CustomEvent(
+						'd2l-search-facets-grouping-change', {
+							bubbles: true, composed: true, detail:
+							{
+								grouping: this.label,
+								selected: this._optionsSelected,
+							}
+						}
+					));
+				}.bind(this));
+
+				// Child elements may not be rendered if this is a <dom-repeat>. Wait for next
+				// render to query for them
+				Polymer.RenderStatus.afterNextRender(this, function() {
+					this._optionElements = Polymer.FlattenedNodesObserver.getFlattenedNodes(this)
+						.filter(function(n) { return n.nodeType === Node.ELEMENT_NODE; });
+
+					if (!this.initiallyShown) {
+						this.initiallyShown = this._optionElements.length;
+					}
+
+					this._showMoreButtonVisible = this.initiallyShown < this._optionElements.length;
+					this._updateOptionVisibility('none');
+				}.bind(this));
+			}
+
+			_showMore() {
+				this._updateOptionVisibility('inline-block');
+				this._showMoreButtonVisible = false;
+			}
+
+			_updateOptionVisibility(display) {
+				for (let index = this.initiallyShown; index < this._optionElements.length; index++) {
+					this._optionElements[index].style.display = display;
+				}
+			}
+
+		}
+		customElements.define(SearchFacetsGrouping.is, SearchFacetsGrouping);
+	</script>
+</dom-module>

--- a/d2l-search-facets-option.html
+++ b/d2l-search-facets-option.html
@@ -1,14 +1,12 @@
 <link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="../d2l-inputs/d2l-input-checkbox.html">
+<link rel="import" href="../d2l-localize-behavior/d2l-localize-behavior.html">
 
 <dom-module id="d2l-search-facets-option">
 	<template strip-whitespace>
 		<style>
 			:host {
-				display: inline-block;
-			}
-			.d2l-search-facets-option-checkbox {
-				@apply --d2l-body-compact-text;
+				display: block;
 			}
 		</style>
 		<d2l-input-checkbox
@@ -24,7 +22,12 @@
 		 * `<d2l-search-facets-option>`
 		 * Search facet option, with a count to display the number of results
 		 */
-		class SearchFacetsOption extends Polymer.Element {
+		class SearchFacetsOption extends Polymer.mixinBehaviors(
+			[
+				D2L.PolymerBehaviors.LocalizeBehavior
+			],
+			Polymer.Element
+		) {
 			static get is() { return 'd2l-search-facets-option'; }
 			static get properties() {
 				return {
@@ -78,7 +81,7 @@
 			_getFacetText(text, count) {
 				// TODO: This may change due to localization
 				if (count) {
-					return text + ' ' + '(' + count + ')';
+					return text + ' ' + '(' + this.formatNumber(count) + ')';
 				}
 				return text;
 			}

--- a/d2l-search-facets-option.html
+++ b/d2l-search-facets-option.html
@@ -80,10 +80,9 @@
 
 			_getFacetText(text, count) {
 				// TODO: This may change due to localization
-				if (count) {
-					return text + ' ' + '(' + this.formatNumber(count) + ')';
-				}
-				return text;
+				return count
+					? `${text} (${this.formatNumber(count)})`
+					: text;
 			}
 
 			_handleChange(e) {

--- a/d2l-search-facets-option.html
+++ b/d2l-search-facets-option.html
@@ -12,9 +12,9 @@
 			}
 		</style>
 		<d2l-input-checkbox
-			checked={{checked::change}}
+			checked=[[checked]]
 			disabled=[[disabled]]
-			name="[[name]]"
+			name="[[text]]"
 			on-change="_handleChange"
 			class="d2l-search-facets-option-checkbox"
 		>[[_facetText]]</d2l-input-checkbox>
@@ -48,7 +48,7 @@
 					* The number of search results for this option
 					*/
 					count: {
-						type: String,
+						type: Number,
 					},
 					/**
 					* Whether this option should be disabled
@@ -59,17 +59,16 @@
 						value: false
 					},
 					/**
-					* Gets or sets the checkbox name, "" by default.
-					*/
-					name: {
-						type: String,
-						reflectToAttribute: true,
-						value: ''
-					},
-					/**
 					* The text for this option
 					*/
 					text: {
+						type: String,
+						value: ''
+					},
+					/**
+					* The value of this option
+					*/
+					value: {
 						type: String,
 						value: ''
 					},
@@ -87,7 +86,14 @@
 			_handleChange(e) {
 				this.dispatchEvent(new CustomEvent(
 					'd2l-search-facets-option-change',
-					{ bubbles: true, composed: true, detail: { option: this.text, checked: e.target.checked } }
+					{
+						bubbles: true,
+						composed: true,
+						detail: {
+							checked: e.target.checked,
+							value: this.value,
+						}
+					}
 				));
 			}
 

--- a/d2l-search-facets-option.html
+++ b/d2l-search-facets-option.html
@@ -1,0 +1,97 @@
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../d2l-inputs/d2l-input-checkbox.html">
+
+<dom-module id="d2l-search-facets-option">
+	<template strip-whitespace>
+		<style>
+			:host {
+				display: inline-block;
+			}
+			.d2l-search-facets-option-checkbox {
+				@apply --d2l-body-compact-text;
+			}
+		</style>
+		<d2l-input-checkbox
+			checked={{checked::change}}
+			disabled=[[disabled]]
+			name="[[name]]"
+			on-change="_handleChange"
+			class="d2l-search-facets-option-checkbox"
+		>[[_facetText]]</d2l-input-checkbox>
+	</template>
+	<script>
+		/**
+		 * `<d2l-search-facets-option>`
+		 * Search facet option, with a count to display the number of results
+		 */
+		class SearchFacetsOption extends Polymer.Element {
+			static get is() { return 'd2l-search-facets-option'; }
+			static get properties() {
+				return {
+					/**
+					* The text displayed for this option. Adds the count next to the text if present
+					*/
+					_facetText: {
+						type: String,
+						value: '',
+						computed: '_getFacetText(text, count)'
+					},
+					/**
+					* Whether the option is selected or not. This property matches the value of
+					* the d2l-input-checkbox
+					*/
+					checked: {
+						type: Boolean,
+						reflectToAttribute: true,
+					},
+					/**
+					* The number of search results for this option
+					*/
+					count: {
+						type: String,
+					},
+					/**
+					* Whether this option should be disabled
+					*/
+					disabled: {
+						type: Boolean,
+						reflectToAttribute: true,
+						value: false
+					},
+					/**
+					* Gets or sets the checkbox name, "" by default.
+					*/
+					name: {
+						type: String,
+						reflectToAttribute: true,
+						value: ''
+					},
+					/**
+					* The text for this option
+					*/
+					text: {
+						type: String,
+						value: ''
+					},
+				};
+			}
+
+			_getFacetText(text, count) {
+				// TODO: This may change due to localization
+				if (count) {
+					return text + ' ' + '(' + count + ')';
+				}
+				return text;
+			}
+
+			_handleChange(e) {
+				this.dispatchEvent(new CustomEvent(
+					'd2l-search-facets-option-change',
+					{ bubbles: true, composed: true, detail: { option: this.text, checked: e.target.checked } }
+				));
+			}
+
+		}
+		customElements.define(SearchFacetsOption.is, SearchFacetsOption);
+	</script>
+</dom-module>

--- a/d2l-search-facets-option.html
+++ b/d2l-search-facets-option.html
@@ -86,17 +86,11 @@
 			}
 
 			_handleChange(e) {
-				this.dispatchEvent(new CustomEvent(
-					'd2l-search-facets-option-change',
-					{
-						bubbles: true,
-						composed: true,
-						detail: {
-							checked: e.target.checked,
-							value: this.value,
-						}
-					}
-				));
+				this.dispatchEvent(new CustomEvent('d2l-search-facets-option-change', {
+					bubbles: true,
+					composed: true,
+					detail: { checked: e.target.checked, option: this.value }
+				}));
 			}
 
 		}

--- a/d2l-search-facets.html
+++ b/d2l-search-facets.html
@@ -19,6 +19,17 @@
 			static get properties() {
 				return {
 					/**
+					* Reference to bound listener functions to be removed in disconnectedCallback
+					*/
+					_boundListeners: {
+						type: Object,
+						value: function() {
+							return {
+								_onFacetGroupingChange: null,
+							};
+						}
+					},
+					/**
 					* An object that contains all selected options under the respective groupings.
 					* (e.g., { groupingA: ['optionA', ...] , groupingB: [...] })
 					*/
@@ -31,25 +42,35 @@
 
 			connectedCallback() {
 				super.connectedCallback();
-				this.addEventListener('d2l-search-facets-grouping-change', function(e) {
-					this.optionsSelected[e.detail.grouping] = e.detail.selected;
-					this.dispatchEvent(new CustomEvent(
-						'd2l-search-facets-change',
-						{ bubbles: true, composed: true, detail: this.optionsSelected }
-					));
-				}.bind(this));
 
-				// Query for the initial groupings and initialize the selected options
 				Polymer.RenderStatus.afterNextRender(this, function() {
+					this._boundListeners._onFacetGroupingChange = this._onFacetGroupingChange.bind(this);
+					this.addEventListener('d2l-search-facets-grouping-change',
+						this._boundListeners._onFacetGroupingChange);
+					// Query for the initial groupings and initialize the selected options
 					const groupings = Polymer.FlattenedNodesObserver.getFlattenedNodes(this)
 						.filter(function(n) { return n.nodeType === Node.ELEMENT_NODE; });
 
 					groupings.forEach(function(grouping) {
-						if (grouping.label) {
-							this.optionsSelected[grouping.label] = [];
+						if (grouping.value) {
+							this.optionsSelected[grouping.value] = [];
 						}
 					}.bind(this));
 				}.bind(this));
+			}
+
+			disconnectedCallback() {
+				super.disconnectedCallback();
+				this.removeEventListener('d2l-search-facets-grouping-change',
+					this._boundListeners._onFacetGroupingChange);
+			}
+
+			_onFacetGroupingChange(e) {
+				this.optionsSelected[e.detail.grouping] = e.detail.selected;
+				this.dispatchEvent(new CustomEvent(
+					'd2l-search-facets-change',
+					{ bubbles: true, composed: true, detail: this.optionsSelected }
+				));
 			}
 		}
 

--- a/d2l-search-facets.html
+++ b/d2l-search-facets.html
@@ -1,0 +1,58 @@
+<link rel="import" href="../polymer/polymer-element.html">
+
+<dom-module id="d2l-search-facets">
+	<template strip-whitespace>
+		<style>
+			:host {
+				display: inline-block;
+			}
+		</style>
+		<slot></slot>
+	</template>
+	<script>
+		/**
+		 * `<d2l-search-facets>`
+		 * Polymer-based web component for D2L search facets.
+		 */
+		class SearchFacets extends Polymer.Element {
+			static get is() { return 'd2l-search-facets'; }
+			static get properties() {
+				return {
+					/**
+					* An object that contains all selected options under the respective groupings.
+					* (e.g., { groupingA: ['optionA', ...] , groupingB: [...] })
+					*/
+					optionsSelected: {
+						type: Object,
+						value: function() { return {}; },
+					}
+				};
+			}
+
+			connectedCallback() {
+				super.connectedCallback();
+				this.addEventListener('d2l-search-facets-grouping-change', function(e) {
+					this.optionsSelected[e.detail.grouping] = e.detail.selected;
+					this.dispatchEvent(new CustomEvent(
+						'd2l-search-facets-change',
+						{ bubbles: true, composed: true, detail: this.optionsSelected }
+					));
+				}.bind(this));
+
+				// Query for the initial groupings and initialize the selected options
+				Polymer.RenderStatus.afterNextRender(this, function() {
+					const groupings = Polymer.FlattenedNodesObserver.getFlattenedNodes(this)
+						.filter(function(n) { return n.nodeType === Node.ELEMENT_NODE; });
+
+					groupings.forEach(function(grouping) {
+						if (grouping.label) {
+							this.optionsSelected[grouping.label] = [];
+						}
+					}.bind(this));
+				}.bind(this));
+			}
+		}
+
+		customElements.define(SearchFacets.is, SearchFacets);
+	</script>
+</dom-module>

--- a/d2l-search-facets.html
+++ b/d2l-search-facets.html
@@ -4,7 +4,7 @@
 	<template strip-whitespace>
 		<style>
 			:host {
-				display: inline-block;
+				display: block;
 			}
 		</style>
 		<slot></slot>

--- a/d2l-search-facets.html
+++ b/d2l-search-facets.html
@@ -29,14 +29,6 @@
 							};
 						}
 					},
-					/**
-					* An object that contains all selected options under the respective groupings.
-					* (e.g., { groupingA: ['optionA', ...] , groupingB: [...] })
-					*/
-					optionsSelected: {
-						type: Object,
-						value: function() { return {}; },
-					}
 				};
 			}
 
@@ -47,30 +39,20 @@
 					this._boundListeners._onFacetGroupingChange = this._onFacetGroupingChange.bind(this);
 					this.addEventListener('d2l-search-facets-grouping-change',
 						this._boundListeners._onFacetGroupingChange);
-					// Query for the initial groupings and initialize the selected options
-					const groupings = Polymer.FlattenedNodesObserver.getFlattenedNodes(this)
-						.filter(function(n) { return n.nodeType === Node.ELEMENT_NODE; });
-
-					groupings.forEach(function(grouping) {
-						if (grouping.value) {
-							this.optionsSelected[grouping.value] = [];
-						}
-					}.bind(this));
 				}.bind(this));
 			}
 
 			disconnectedCallback() {
 				super.disconnectedCallback();
+
 				this.removeEventListener('d2l-search-facets-grouping-change',
 					this._boundListeners._onFacetGroupingChange);
 			}
 
 			_onFacetGroupingChange(e) {
-				this.optionsSelected[e.detail.grouping] = e.detail.selected;
-				this.dispatchEvent(new CustomEvent(
-					'd2l-search-facets-change',
-					{ bubbles: true, composed: true, detail: this.optionsSelected }
-				));
+				this.dispatchEvent(new CustomEvent('d2l-search-facets-change', {
+					bubbles: true, composed: true, detail: e.detail
+				}));
 			}
 		}
 

--- a/demo/d2l-search-facets-demo-components.html
+++ b/demo/d2l-search-facets-demo-components.html
@@ -11,6 +11,7 @@
 							value$="[[searchFacet.value]]"
 							text$="[[searchFacet.name]]"
 							count="[[searchFacet.count]]"
+							checked="[[searchFacet.checked]]"
 						></d2l-search-facets-option>
 					</template>
 				</d2l-search-facets-grouping>
@@ -55,7 +56,7 @@
 						name: 'Rating',
 						value: 'rating',
 						options: [
-							{ name: 'Excellent', value: 'excellent', count: 1000 },
+							{ name: 'Excellent', value: 'excellent', count: 1000, checked: true },
 							{ name: 'Good', value: 'good', count: 100 },
 							{ name: 'Poor', value: 'poor', count: 10 },
 						],

--- a/demo/d2l-search-facets-demo-components.html
+++ b/demo/d2l-search-facets-demo-components.html
@@ -5,7 +5,7 @@
 	<template>
 		<d2l-search-facets>
 			<template items="[[searchFacets]]" is="dom-repeat">
-				<d2l-search-facets-grouping value="[[item.value]]" text="[[item.name]]" hide-after="[[item.hideAfter]]">
+				<d2l-search-facets-grouping value="[[item.value]]" text="[[item.name]]">
 					<template items="[[item.options]]" is="dom-repeat" as="searchFacet">
 						<d2l-search-facets-option
 							value$="[[searchFacet.value]]"
@@ -50,7 +50,6 @@
 							{ name: 'In Progress', value: 'in-progress', count: 1 },
 							{ name: 'Complete', value: 'complete', count: 10 },
 						],
-						hideAfter: 2,
 					},
 					{
 						name: 'Rating',
@@ -60,7 +59,6 @@
 							{ name: 'Good', value: 'good', count: 100 },
 							{ name: 'Poor', value: 'poor', count: 10 },
 						],
-						hideAfter: 2,
 					},
 					{
 						name: 'Format',

--- a/demo/d2l-search-facets-demo-components.html
+++ b/demo/d2l-search-facets-demo-components.html
@@ -1,0 +1,71 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../all-imports.html">
+
+<dom-module id="d2l-demo-templated-search-facets">
+	<template>
+		<d2l-search-facets>
+			<template items="{{searchFacets}}" is="dom-repeat">
+				<d2l-search-facets-grouping label$="{{item.name}}" initially-shown="{{item.initiallyShown}}">
+					<template items="{{item.options}}" is="dom-repeat" as="searchFacet">
+						<d2l-search-facets-option text$="{{searchFacet.name}}" count="{{searchFacet.count}}">
+						</d2l-search-facets-option>
+					</template>
+				</d2l-search-facets-grouping>
+			</template>
+		</d2l-search-facets>
+	</template>
+	<script>
+		/**
+		 * An example of templated search facets. The data can potentially be retrieved from an
+		 * external source, and given to the search-facets to handle.
+		**/
+		class TemplatedSearchFacetsDemo extends Polymer.Element {
+			static get is() { return 'd2l-demo-templated-search-facets'; }
+			static get properties() {
+				return {
+					searchFacets: {
+						type: Array,
+						value: function() { return []; }
+					}
+				};
+			}
+
+			constructor() {
+				super();
+			}
+
+			connectedCallback() {
+				super.connectedCallback();
+				this.searchFacets = [
+					{
+						name: 'My Status',
+						options: [
+							{ name: 'My Courses', count: 21 },
+							{ name: 'On My List', count: 1 },
+							{ name: 'In Progress', count: 1 },
+							{ name: 'Complete', count: 10 },
+						],
+						initiallyShown: 2,
+					},
+					{
+						name: 'Rating',
+						options: [
+							{ name: 'Excellent', count: '1000+' },
+							{ name: 'Good', count: 100 },
+							{ name: 'Poor', count: 10 },
+						],
+						initiallyShown: 2,
+					},
+					{
+						name: 'Format',
+						options: [
+							{ name: 'Online', count: '1000+' },
+							{ name: 'In-Class', count: 1 },
+						]
+					},
+				];
+			}
+		}
+		customElements.define(TemplatedSearchFacetsDemo.is, TemplatedSearchFacetsDemo);
+	</script>
+</dom-module>

--- a/demo/d2l-search-facets-demo-components.html
+++ b/demo/d2l-search-facets-demo-components.html
@@ -4,11 +4,14 @@
 <dom-module id="d2l-demo-templated-search-facets">
 	<template>
 		<d2l-search-facets>
-			<template items="{{searchFacets}}" is="dom-repeat">
-				<d2l-search-facets-grouping label$="{{item.name}}" initially-shown="{{item.initiallyShown}}">
-					<template items="{{item.options}}" is="dom-repeat" as="searchFacet">
-						<d2l-search-facets-option text$="{{searchFacet.name}}" count="{{searchFacet.count}}">
-						</d2l-search-facets-option>
+			<template items="[[searchFacets]]" is="dom-repeat">
+				<d2l-search-facets-grouping value="[[item.value]]" text="[[item.name]]" hide-after="[[item.hideAfter]]">
+					<template items="[[item.options]]" is="dom-repeat" as="searchFacet">
+						<d2l-search-facets-option
+							value$="[[searchFacet.value]]"
+							text$="[[searchFacet.name]]"
+							count="[[searchFacet.count]]"
+						></d2l-search-facets-option>
 					</template>
 				</d2l-search-facets-grouping>
 			</template>
@@ -39,28 +42,31 @@
 				this.searchFacets = [
 					{
 						name: 'My Status',
+						value: 'status',
 						options: [
-							{ name: 'My Courses', count: 21 },
-							{ name: 'On My List', count: 1 },
-							{ name: 'In Progress', count: 1 },
-							{ name: 'Complete', count: 10 },
+							{ name: 'My Courses', value: 'my-courses', count: 21 },
+							{ name: 'On My List', value: 'my-list', count: 1 },
+							{ name: 'In Progress', value: 'in-progress', count: 1 },
+							{ name: 'Complete', value: 'complete', count: 10 },
 						],
-						initiallyShown: 2,
+						hideAfter: 2,
 					},
 					{
 						name: 'Rating',
+						value: 'rating',
 						options: [
-							{ name: 'Excellent', count: '1000+' },
-							{ name: 'Good', count: 100 },
-							{ name: 'Poor', count: 10 },
+							{ name: 'Excellent', value: 'excellent', count: 1000 },
+							{ name: 'Good', value: 'good', count: 100 },
+							{ name: 'Poor', value: 'poor', count: 10 },
 						],
-						initiallyShown: 2,
+						hideAfter: 2,
 					},
 					{
 						name: 'Format',
+						value: 'format',
 						options: [
-							{ name: 'Online', count: '1000+' },
-							{ name: 'In-Class', count: 1 },
+							{ name: 'Online', value: 'online', count: 1000 },
+							{ name: 'In-Class', value: 'in-class', count: 1 },
 						]
 					},
 				];

--- a/demo/d2l-search-facets.html
+++ b/demo/d2l-search-facets.html
@@ -28,17 +28,15 @@
 			<demo-snippet>
 				<template>
 					<d2l-search-facets>
-						<d2l-search-facets-grouping value="status" text="My Status" hide-after="2">
+						<d2l-search-facets-grouping id="status" value="status" text="My Status" has-more>
 							<d2l-search-facets-option value="new-courses" text="New Courses Only" count="21"></d2l-search-facets-option>
 							<d2l-search-facets-option value="my-list" text="On My List" count="1"></d2l-search-facets-option>
-							<d2l-search-facets-option value="in-progress" text="In Progress" count="1"></d2l-search-facets-option>
-							<d2l-search-facets-option value="completed" text="Completed" count="10000"></d2l-search-facets-option>
 						</d2l-search-facets-grouping>
-						<d2l-search-facets-grouping value="format" text="Format" hide-after="1">
+						<d2l-search-facets-grouping id="format" value="format" text="Format" has-more>
 							<d2l-search-facets-option value="online" text="Online" count="1"></d2l-search-facets-option>
 							<d2l-search-facets-option value="in-class" text="In-Class" count="2"></d2l-search-facets-option>
 						</d2l-search-facets-grouping>
-						<d2l-search-facets-grouping value="location" text="Location">
+						<d2l-search-facets-grouping value="location" value="location" text="Location">
 							<d2l-search-facets-option value="outside" text="Outside"></d2l-search-facets-option>
 							<d2l-search-facets-option value="inside" text="Inside"></d2l-search-facets-option>
 						</d2l-search-facets-grouping>
@@ -58,11 +56,38 @@
 	<script>
 		document.addEventListener('WebComponentsReady', function() {
 			document.body.classList.add('d2l-typography');
+
+			document.addEventListener('d2l-search-facets-change', function(e) {
+				// eslint-disable-next-line no-console
+				console.log(e.detail);
+			});
+
+			document.getElementById('status').addEventListener('d2l-search-facets-grouping-has-more', function(e) {
+				const options = [
+					{ text: 'In Progress', value: 'in-progress', count: '1' },
+					{ text: 'Completed', value: 'completed', count: '10000' }
+				];
+				addOptions(options, e.target);
+			});
+
+			document.getElementById('format').addEventListener('d2l-search-facets-grouping-has-more', function(e) {
+				const options = [
+					{ text: 'Interactive', value: 'interactive', count: '12' },
+					{ text: 'Video Only', value: 'video-only', count: '30' }
+				];
+				addOptions(options, e.target);
+			});
 		});
 
-		document.addEventListener('d2l-search-facets-change', function(e) {
-			// eslint-disable-next-line no-console
-			console.log(e.detail);
-		});
+		function addOptions(options, target) {
+			options.forEach(function(option) {
+				const element = document.createElement('d2l-search-facets-option');
+				element.setAttribute('text', option.text);
+				element.setAttribute('value', option.value);
+				element.setAttribute('count', option.count);
+				target.appendChild(element);
+			});
+			target.removeAttribute('has-more');
+		}
 	</script>
 </html>

--- a/demo/d2l-search-facets.html
+++ b/demo/d2l-search-facets.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-search-facets demo</title>
+		<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../all-imports.html">
+		<link rel="import" href="./d2l-search-facets-demo-components.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles"></style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+		<style>
+			html {
+				font-size: 20px;
+			}
+		</style>
+	</head>
+	<body unresolved class="d2l-typography">
+		<div class="vertical-section-container centered">
+			<h3>d2l-search-facets</h3>
+			<demo-snippet>
+				<template>
+					<d2l-search-facets>
+						<d2l-search-facets-grouping label="My Status" initially-shown="2">
+							<d2l-search-facets-option text="New Courses Only" count="21"></d2l-search-facets-option>
+							<d2l-search-facets-option text="On My List" count="1"></d2l-search-facets-option>
+							<d2l-search-facets-option text="In Progress" count="1"></d2l-search-facets-option>
+							<d2l-search-facets-option text="Completed" count="1"></d2l-search-facets-option>
+						</d2l-search-facets-grouping>
+						<d2l-search-facets-grouping label="Format" initially-shown="1">
+							<d2l-search-facets-option text="Online" count="1"></d2l-search-facets-option>
+							<d2l-search-facets-option text="In-Class" count="2"></d2l-search-facets-option>
+						</d2l-search-facets-grouping>
+						<d2l-search-facets-grouping label="Location">
+							<d2l-search-facets-option text="Outside"></d2l-search-facets-option>
+							<d2l-search-facets-option text="Inside"></d2l-search-facets-option>
+						</d2l-search-facets-grouping>
+					</d2l-search-facets>
+				</template>
+			</demo-snippet>
+		</div>
+		<div class="vertical-section-container centered">
+			<h3>Templated d2l-search-facets demo</h3>
+			<demo-snippet>
+				<template>
+					<d2l-demo-templated-search-facets></d2l-demo-templated-search-facets>
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+	<script>
+		document.addEventListener('WebComponentsReady', function() {
+			document.body.classList.add('d2l-typography');
+		});
+
+		document.addEventListener('d2l-search-facets-change', function(e) {
+			// eslint-disable-next-line no-console
+			console.log(e.detail);
+		});
+	</script>
+</html>

--- a/demo/d2l-search-facets.html
+++ b/demo/d2l-search-facets.html
@@ -28,19 +28,19 @@
 			<demo-snippet>
 				<template>
 					<d2l-search-facets>
-						<d2l-search-facets-grouping label="My Status" initially-shown="2">
-							<d2l-search-facets-option text="New Courses Only" count="21"></d2l-search-facets-option>
-							<d2l-search-facets-option text="On My List" count="1"></d2l-search-facets-option>
-							<d2l-search-facets-option text="In Progress" count="1"></d2l-search-facets-option>
-							<d2l-search-facets-option text="Completed" count="1"></d2l-search-facets-option>
+						<d2l-search-facets-grouping value="status" text="My Status" hide-after="2">
+							<d2l-search-facets-option value="new-courses" text="New Courses Only" count="21"></d2l-search-facets-option>
+							<d2l-search-facets-option value="my-list" text="On My List" count="1"></d2l-search-facets-option>
+							<d2l-search-facets-option value="in-progress" text="In Progress" count="1"></d2l-search-facets-option>
+							<d2l-search-facets-option value="completed" text="Completed" count="10000"></d2l-search-facets-option>
 						</d2l-search-facets-grouping>
-						<d2l-search-facets-grouping label="Format" initially-shown="1">
-							<d2l-search-facets-option text="Online" count="1"></d2l-search-facets-option>
-							<d2l-search-facets-option text="In-Class" count="2"></d2l-search-facets-option>
+						<d2l-search-facets-grouping value="format" text="Format" hide-after="1">
+							<d2l-search-facets-option value="online" text="Online" count="1"></d2l-search-facets-option>
+							<d2l-search-facets-option value="in-class" text="In-Class" count="2"></d2l-search-facets-option>
 						</d2l-search-facets-grouping>
-						<d2l-search-facets-grouping label="Location">
-							<d2l-search-facets-option text="Outside"></d2l-search-facets-option>
-							<d2l-search-facets-option text="Inside"></d2l-search-facets-option>
+						<d2l-search-facets-grouping value="location" text="Location">
+							<d2l-search-facets-option value="outside" text="Outside"></d2l-search-facets-option>
+							<d2l-search-facets-option value="inside" text="Inside"></d2l-search-facets-option>
 						</d2l-search-facets-grouping>
 					</d2l-search-facets>
 				</template>

--- a/test/d2l-search-facets.html
+++ b/test/d2l-search-facets.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-search-facets test</title>
+		<script src="../../webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+		<script src="../../iron-test-helpers/mock-interactions.js"></script>
+		<script src="../../iron-test-helpers/test-helpers.js"></script>
+		<link rel="import" href="../all-imports.html">
+	</head>
+	<body>
+		<test-fixture id="basic">
+			<template>
+				<d2l-search-facets></d2l-search-facets>
+			</template>
+		</test-fixture>
+		<script>
+			describe('<d2l-search-facets>', function() {
+				describe('basic', function() {
+					let basicFixture;
+					beforeEach(function(done) {
+						basicFixture = fixture('basic');
+						Polymer.RenderStatus.afterNextRender(basicFixture, function() {
+							done();
+						});
+					});
+
+					it('should pass', function() {
+						expect(1).to.equal(1);
+					});
+				});
+			});
+		</script>
+	</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -10,10 +10,12 @@
 	<body>
 		<script>
 			WCT.loadSuites([
-				'd2l-search-results-count.html?wc-shadydom=true&wc-ce=true',
+				'd2l-search-facets.html?dom=shadow',
+				'd2l-search-facets.html?wc-shadydom=true&wc-ce=true',
 				'd2l-search-results-count.html?dom=shadow',
-				'd2l-sort-by-dropdown.html?wc-shadydom=true&wc-ce=true',
-				'd2l-sort-by-dropdown.html?dom=shadow'
+				'd2l-search-results-count.html?wc-shadydom=true&wc-ce=true',
+				'd2l-sort-by-dropdown.html?dom=shadow',
+				'd2l-sort-by-dropdown.html?wc-shadydom=true&wc-ce=true'
 			]);
 		</script>
 	</body>


### PR DESCRIPTION
Updated usage:


`<d2l-search-facets>`: 
- Events:
    - Fires an event that indicates the grouping/value that changed, and whether the option is selected(checked) or not
        - e.g., `{ checked: true, option: "online", grouping: "format" }`

`<d2l-search-facets-grouping>`:
- Attributes:
    - `text` (label of the grouping)
    - `value`
    - `hide-after` (how many options are shown initially, default is all)
- Events:
    - Adds grouping to the event to the event fired by`<d2l-search-facets-option>`

`<d2l-search-facets-option>`:
- Attributes:
    - `text` (of the option)
    - `value`
    - `count` (optional)
- Events:
    - Fires an event on selection
        - e.g., `{ option: …, checked: true/false }`

---
<img width="231" alt="screen shot 2018-10-24 at 11 57 06 am" src="https://user-images.githubusercontent.com/6110668/47444209-f7a0d380-d783-11e8-8e63-9d13ce3aaa75.png">


Example usage:
```html
<d2l-search-facets>
  <d2l-search-facets-grouping value="status" text="My Status">
    <d2l-search-facets-option value="new-courses" text="New Courses Only" count="21"></d2l-search-facets-option>
  </d2l-search-facets-grouping>
  <d2l-search-facets-grouping value="format" text="Format" hide-after="1">
    <d2l-search-facets-option value="online" text="Online"></d2l-search-facets-option>
    <d2l-search-facets-option value="in-class" text="In-Class"></d2l-search-facets-option>
  </d2l-search-facets-grouping>
</d2l-search-facets>
```
