### PR TITLE
Emit search field changed event instead of searching here

### DIFF
--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-page.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-page.js
@@ -22,7 +22,7 @@ class D2LFilterDropdownPage extends mixinBehaviors([D2L.PolymerBehaviors.FilterD
 			<d2l-menu label="[[parentTitle]]">
 				<dom-repeat items="[[options]]" as="o">
 					<template>
-					<d2l-menu-item-checkbox text="[[o.title]]" value="[[o.key]]" hidden$="[[!o.display]]" selected=[[o.selected]]></d2l-menu-item-checkbox>
+					<d2l-menu-item-checkbox text="[[o.title]]" value="[[o.key]]" selected=[[o.selected]]></d2l-menu-item-checkbox>
 					</template>
 				</dom-repeat>
 			</d2l-menu>
@@ -45,8 +45,7 @@ class D2LFilterDropdownPage extends mixinBehaviors([D2L.PolymerBehaviors.FilterD
 					// {
 					// 	key: '',
 					// 	title: '',
-					// 	selected: false,
-					// 	display: true
+					// 	selected: false
 					// }
 				]
 			},
@@ -96,19 +95,19 @@ class D2LFilterDropdownPage extends mixinBehaviors([D2L.PolymerBehaviors.FilterD
 	}
 
 	_handleSearchChange(e) {
-		var value = e.detail.value;
-		var clear = value === '';
-		if (clear || value.length) {
-			for (var i = 0; i < this.options.length; i++) {
-				this._setOptionProp('display', clear || this._caseInsensitiveContainsSubstring(this.options[i].title, value), i);
-			}
-		}
-	}
-
-	_caseInsensitiveContainsSubstring(s, sub) {
-		const lowerS = s.toLowerCase();
-		const lowerSub = sub.toLowerCase();
-		return lowerS.indexOf(lowerSub) >= 0;
+		this.dispatchEvent(
+			new CustomEvent(
+				'd2l-filter-dropdown-page-searched',
+				{
+					detail: {
+						value: e.detail.value,
+						categoryKey: this.parentKey
+					},
+					composed: true,
+					bubbles: true
+				}
+			)
+		);
 	}
 
 	_handleMenuItemChange(e) {

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown.js
@@ -64,7 +64,7 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 					// 	options: [{
 					// 		key: '',
 					// 		title: '',
-					// 		selected: false,
+					// 		selected: false
 					// 	}]
 					// }
 				]

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown.js
@@ -156,6 +156,18 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 		}
 	}
 
+	setFilterOptions(categoryKey, options) {
+		const index = this._getFilterIndexFromKey(categoryKey);
+		if (index >= 0) {
+			this._setProp('options', [], index);
+			options.forEach(o => {
+				this.addFilterOption(categoryKey, o.key, o.title, o.selected);
+			});
+		} else {
+			throw new Error(`Cannot find category with key ${categoryKey}`);
+		}
+	}
+
 	updateFilterOptionSelectedStatus(categoryKey, optionKey, value) {
 		const cIndex = this._getCategoryIndexFromKey(categoryKey);
 		if (cIndex >= 0) {

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown.js
@@ -157,7 +157,7 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 	}
 
 	setFilterOptions(categoryKey, options) {
-		const index = this._getFilterIndexFromKey(categoryKey);
+		const index = this._getCategoryIndexFromKey(categoryKey);
 		if (index >= 0) {
 			this._setProp('options', [], index);
 			options.forEach(o => {

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown.js
@@ -65,7 +65,6 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 					// 		key: '',
 					// 		title: '',
 					// 		selected: false,
-					// 		display: true
 					// 	}]
 					// }
 				]

--- a/demo/d2l-filter-dropdown/d2l-filter-dropdown.html
+++ b/demo/d2l-filter-dropdown/d2l-filter-dropdown.html
@@ -61,7 +61,7 @@
 				title: 'Cat ' + i,
 				numSelected: options.filter(o => o.selected).length,
 				options: options
-			}
+			};
 		}
 
 		function search(search, category, data) {
@@ -93,7 +93,7 @@
 					if (option.key === e.detail.optionKey) {
 						option.selected = e.detail.newValue;
 					}
-				})
+				});
 			});
 
 			// Perform search

--- a/demo/d2l-filter-dropdown/d2l-filter-dropdown.html
+++ b/demo/d2l-filter-dropdown/d2l-filter-dropdown.html
@@ -41,7 +41,6 @@
 			<demo-snippet>
 				<template strip-whitespace>
 					<d2l-filter-dropdown class="with-search"></d2l-filter-dropdown>
-					<d2l-filter-dropdown disable-search class="no-search"></d2l-filter-dropdown>
 				</template>
 			</demo-snippet>
 		</div>
@@ -93,6 +92,16 @@
 					if (option.key === e.detail.optionKey) {
 						option.selected = e.detail.newValue;
 					}
+				});
+
+				// Listen for clear to wipe selected state
+				filter.addEventListener('d2l-filter-dropdown-cleared', () => {
+					Object.keys(data).forEach(categoryKey => {
+						data[categoryKey].numSelected = 0;
+						data[categoryKey].options.forEach(option => {
+							option.selected = false;
+						});
+					});
 				});
 			});
 

--- a/demo/d2l-filter-dropdown/d2l-filter-dropdown.html
+++ b/demo/d2l-filter-dropdown/d2l-filter-dropdown.html
@@ -47,19 +47,66 @@
 		</div>
 	</body>
 	<script type="module">
-		window.requestAnimationFrame(function() {
-			var filter = document.querySelector('d2l-filter-dropdown.with-search');
-			for (var i = 0; i < 6; i++) {
-				filter.addFilterCategory('Cat' + i, 'Cat ' + i, i === 0);
-				for (var j = 0; j < 20; j++) {
-					filter.addFilterOption('Cat' + i, `option${i}-${j}`, `Option ${i}-${j}`, j === i);
-				}
+		function generateOptions(i) {
+			const options = [];
+			for (let j = 0; j < 20; j++) {
+				options.push({key: `option${i}-${j}`, title: `Option ${i}-${j}`, selected: j === i});
 			}
-			filter = document.querySelector('d2l-filter-dropdown.no-search');
-			for (i = 0; i < 4; i++) {
-				filter.addFilterCategory('NCat' + i, 'NCat ' + i, i === 0);
-				for (j = 0; j <= i; j++) {
-					filter.addFilterOption('NCat' + i, `Noption${i}-${j}`, `NOption ${i}-${j}`, j === i);
+			return options;
+		}
+		function generateCategory(i) {
+			const options = generateOptions(i);
+			return {
+				key: 'Cat' + i,
+				title: 'Cat ' + i,
+				numSelected: options.filter(o => o.selected).length,
+				options: options
+			}
+		}
+
+		function search(search, category, data) {
+			if (search === '') {
+				return data[category].options;
+			}
+
+			return data[category].options.filter(opt => opt.title.indexOf(search) >= 0);
+		}
+		window.requestAnimationFrame(function() {
+			const filter = document.querySelector('d2l-filter-dropdown.with-search');
+			const data = {};
+			// Generate mirror of data
+			for (let i = 0; i < 6; i++) {
+				data['Cat' + i] = generateCategory(i);
+			}
+
+			// Set up filter with our generated data
+			Object.keys(data).forEach(categoryKey => {
+				filter.addFilterCategory(categoryKey, data[categoryKey].title, data[categoryKey].numSelected);
+				data[categoryKey].options.forEach(option => {
+					filter.addFilterOption(categoryKey, option.key, option.title, option.selected);
+				});
+			});
+
+			// Listen for changes so search doesn't wipe the selected state
+			filter.addEventListener('d2l-filter-dropdown-option-changed', e => {
+				data[e.detail.categoryKey].options.forEach(option => {
+					if (option.key === e.detail.optionKey) {
+						option.selected = e.detail.newValue;
+					}
+				})
+			});
+
+			// Perform search
+			filter.addEventListener('d2l-filter-dropdown-page-searched', e => {
+				const newOptions = search(e.detail.value, e.detail.categoryKey, data);
+				filter.setFilterOptions(e.detail.categoryKey, newOptions);
+			});
+
+			const filterNoSearch = document.querySelector('d2l-filter-dropdown.no-search');
+			for (let i = 0; i < 4; i++) {
+				filterNoSearch.addFilterCategory('NCat' + i, 'NCat ' + i, i === 0);
+				for (let j = 0; j <= i; j++) {
+					filterNoSearch.addFilterOption('NCat' + i, `Noption${i}-${j}`, `NOption ${i}-${j}`, j === i);
 				}
 			}
 		});

--- a/test/d2l-filter-dropdown/d2l-filter-dropdown.js
+++ b/test/d2l-filter-dropdown/d2l-filter-dropdown.js
@@ -79,247 +79,288 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 	}
 
 	suite('d2l-filter-dropdown', function() {
-		setup(function(done) {
-			filter = fixture('basic');
-			categories = [
-				{key: 'cat1', title: 'Cat 1'},
-				{key: 'cat2', title: 'Cat 2'},
-				{key: 'cat3', title: 'Cat 3'}
-			];
-			options = [
-				{cat: 'cat1', key: 'opt1-1', title: 'Opt 1-1'},
-				{cat: 'cat1', key: 'opt1-2', title: 'Opt 1-2'},
-				{cat: 'cat2', key: 'opt2-1', title: 'Opt 2-1'},
-				{cat: 'cat2', key: 'opt2-2', title: 'Opt 2-2'},
-				{cat: 'cat3', key: 'opt3-1', title: 'Opt 3-1'},
-				{cat: 'cat3', key: 'opt3-2', title: 'Opt 3-2'}
-			];
-			afterNextRender(filter, done);
-		});
-		test('instantiating the element works', function() {
-			assert.equal('d2l-filter-dropdown', filter.tagName.toLowerCase());
-		});
-		test('attributes are set correctly', function() {
-			assert.equal(false, filter.disableSearch);
-		});
-		test('filters are imported correctly', function() {
-			var expected = _getExpectedAndImport(filter);
-			assert.deepEqual(expected, filter._filters);
-		});
-		test('clear button is hidden if no filters are applied', function() {
-			var clearButton = filter.shadowRoot.querySelector('d2l-button-subtle');
-			assert.isTrue(clearButton.hidden);
-		});
-		test('filter category num selected is correct after importing filters and clear button is visible', function() {
-			var clearButton = filter.shadowRoot.querySelector('d2l-button-subtle');
-			var selected = [0, 4, 5];
-			var expectedNum = _setSelectedOptions(selected);
-			var expected = _getExpectedAndImport(filter);
 
-			assert.isFalse(clearButton.hidden);
-			assert.deepEqual(expected, filter._filters);
-			for (var i = 0; i < filter._filters.length; i++) {
-				var f = filter._filters[i];
-				for (var j = 0; j < f.options.length; j++) {
-					assert.equal(f.options[j].selected, _getOptionByKeys(f.key, f.options[j].key).selected);
-				}
-				assert.equal(expectedNum[f.key], f.numSelected);
-			}
+		setup(() => {
+			filter = fixture('basic');
 		});
-		test('filter category num selected is correct after changing option selected status', function(done) {
-			_getExpectedAndImport(filter);
-			filter._filters.forEach(f => {
-				assert.equal(0, f.numSelected);
+
+		suite('unit', () => {
+			suite('setFilterOptions', () => {
+				test('replaces filter options', () => {
+					const categoryKey = 'This is a category key';
+					const options = [
+						{ key: 10, title: 'title', selected: true },
+						{ key: 30, title: 'title2', selected: false }
+					];
+					const categoryIndex = 123;
+
+					const getIndexStub = sinon.stub(filter, '_getCategoryIndexFromKey');
+					const setPropStub = sinon.stub(filter, '_setProp');
+					const addFilterStub = sinon.stub(filter, 'addFilterOption');
+					getIndexStub.withArgs(categoryKey).returns(categoryIndex);
+
+					filter.setFilterOptions(categoryKey, options);
+
+					expect(setPropStub.calledWith('options', [], categoryIndex)).to.be.true;
+					expect(addFilterStub.calledTwice).to.be.true;
+					expect(addFilterStub.calledWith(categoryKey, 10, 'title', true)).to.be.true;
+					expect(addFilterStub.calledWith(categoryKey, 30, 'title2', false)).to.be.true;
+				});
+				test('throws on bad category key', () => {
+					const categoryKey = 'This is also a category key';
+
+					const getIndexStub = sinon.stub(filter, '_getCategoryIndexFromKey');
+					getIndexStub.withArgs(categoryKey).returns(-1);
+
+					const performTest = () => filter.setFilterOptions(categoryKey, []);
+
+					expect(performTest).to.throw(categoryKey);
+				});
 			});
-			window.requestAnimationFrame(function() {
-				var pages = _getPages();
-				for (var i = 0; i < pages.length; i++) {
-					var options = _getOptions(pages[i]);
-					for (var j = 0; j < i && j < options.length; j++) {
-						afterNextRender(options[j], function(option) {
-							MockInteractions.click(option);
-						}, [options[j]]);
+		});
+
+		suite('integration', () => {
+			setup(function(done) {
+				categories = [
+					{key: 'cat1', title: 'Cat 1'},
+					{key: 'cat2', title: 'Cat 2'},
+					{key: 'cat3', title: 'Cat 3'}
+				];
+				options = [
+					{cat: 'cat1', key: 'opt1-1', title: 'Opt 1-1'},
+					{cat: 'cat1', key: 'opt1-2', title: 'Opt 1-2'},
+					{cat: 'cat2', key: 'opt2-1', title: 'Opt 2-1'},
+					{cat: 'cat2', key: 'opt2-2', title: 'Opt 2-2'},
+					{cat: 'cat3', key: 'opt3-1', title: 'Opt 3-1'},
+					{cat: 'cat3', key: 'opt3-2', title: 'Opt 3-2'}
+				];
+				afterNextRender(filter, done);
+			});
+			test('instantiating the element works', function() {
+				assert.equal('d2l-filter-dropdown', filter.tagName.toLowerCase());
+			});
+			test('attributes are set correctly', function() {
+				assert.equal(false, filter.disableSearch);
+			});
+			test('filters are imported correctly', function() {
+				var expected = _getExpectedAndImport(filter);
+				assert.deepEqual(expected, filter._filters);
+			});
+			test('clear button is hidden if no filters are applied', function() {
+				var clearButton = filter.shadowRoot.querySelector('d2l-button-subtle');
+				assert.isTrue(clearButton.hidden);
+			});
+			test('filter category num selected is correct after importing filters and clear button is visible', function() {
+				var clearButton = filter.shadowRoot.querySelector('d2l-button-subtle');
+				var selected = [0, 4, 5];
+				var expectedNum = _setSelectedOptions(selected);
+				var expected = _getExpectedAndImport(filter);
+
+				assert.isFalse(clearButton.hidden);
+				assert.deepEqual(expected, filter._filters);
+				for (var i = 0; i < filter._filters.length; i++) {
+					var f = filter._filters[i];
+					for (var j = 0; j < f.options.length; j++) {
+						assert.equal(f.options[j].selected, _getOptionByKeys(f.key, f.options[j].key).selected);
 					}
+					assert.equal(expectedNum[f.key], f.numSelected);
 				}
-				window.setTimeout(function() {
-					for (i = 0; i < filter._filters.length; i++) {
-						assert.equal(Math.min(i, filter._filters[i].options.length), filter._filters[i].numSelected);
+			});
+			test('filter category num selected is correct after changing option selected status', function(done) {
+				_getExpectedAndImport(filter);
+				filter._filters.forEach(f => {
+					assert.equal(0, f.numSelected);
+				});
+				window.requestAnimationFrame(function() {
+					var pages = _getPages();
+					for (var i = 0; i < pages.length; i++) {
+						var options = _getOptions(pages[i]);
+						for (var j = 0; j < i && j < options.length; j++) {
+							afterNextRender(options[j], function(option) {
+								MockInteractions.click(option);
+							}, [options[j]]);
+						}
+					}
+					window.setTimeout(function() {
+						for (i = 0; i < filter._filters.length; i++) {
+							assert.equal(Math.min(i, filter._filters[i].options.length), filter._filters[i].numSelected);
+						}
+						done();
+					}, 100);
+				});
+			});
+			test('filter category num selected count does not display if count is 0', function(done) {
+				_getExpectedAndImport(filter);
+				window.requestAnimationFrame(function() {
+					var tabs = _getTabPanels();
+					for (var i = 0; i < tabs.length; i++) {
+						assert.equal(tabs[i].text, categories[i].title);
 					}
 					done();
-				}, 100);
+				});
 			});
-		});
-		test('filter category num selected count does not display if count is 0', function(done) {
-			_getExpectedAndImport(filter);
-			window.requestAnimationFrame(function() {
-				var tabs = _getTabPanels();
-				for (var i = 0; i < tabs.length; i++) {
-					assert.equal(tabs[i].text, categories[i].title);
-				}
-				done();
-			});
-		});
-		test('category selected count displays correctly', function(done) {
-			var expectedNum = _setSelectedOptions([0, 4, 5]);
-			_getExpectedAndImport(filter);
-			window.requestAnimationFrame(function() {
-				var tabs = _getTabPanels();
-				for (var i = 0; i < tabs.length; i++) {
-					var expectedNumText = expectedNum[categories[i].key] !== 0 ? ` (${expectedNum[categories[i].key]})` : '';
-					assert.equal(tabs[i].text, `${categories[i].title}${expectedNumText}`);
-				}
-				done();
-			});
-		});
-		test('total filter count is not shown when no options are selected', function(done) {
-			_getExpectedAndImport(filter);
-			window.requestAnimationFrame(function() {
-				var totalCount = _getDropdownOpener();
-				assert.equal('Filter', totalCount.text);
-				done();
-			});
-		});
-		test('total filter count is displayed correctly when one option is selected', function(done) {
-			_setSelectedOptions([2]);
-			_getExpectedAndImport(filter);
-			window.requestAnimationFrame(function() {
-				var totalCount = _getDropdownOpener();
-				assert.equal('Filter: 1 Filter', totalCount.text);
-				done();
-			});
-		});
-		test('total filter count is displayed correctly when multiple options are selected', function(done) {
-			var selected = [0, 4, 5];
-			_setSelectedOptions(selected);
-			_getExpectedAndImport(filter);
-			window.requestAnimationFrame(function() {
-				var totalCount = _getDropdownOpener();
-				assert.equal(`Filter: ${selected.length} Filters`, totalCount.text);
-				done();
-			});
-		});
-		test('filter categories display correctly', function(done) {
-			_getExpectedAndImport(filter);
-			window.requestAnimationFrame(function() {
-				var headers = _getTabPanels();
-				assert.equal(filter._filters.length, headers.length);
-				for (var i = 0; i < headers.length; i++) {
-					assert.equal(filter._filters[i].title, headers[i].text);
-				}
-				done();
-			});
-		});
-		test('filter options display correctly', function(done) {
-			_getExpectedAndImport(filter);
-			window.requestAnimationFrame(function() {
-				var pages = _getPages();
-				for (var i = 0; i < pages.length; i++) {
-					var opts = _getOptions(pages[i]);
-					assert.equal(pages[i].options.length, opts.length);
-					for (var j = 0; j < opts.length; j++) {
-						assert.equal(pages[i].options[j].title, opts[j].text);
+			test('category selected count displays correctly', function(done) {
+				var expectedNum = _setSelectedOptions([0, 4, 5]);
+				_getExpectedAndImport(filter);
+				window.requestAnimationFrame(function() {
+					var tabs = _getTabPanels();
+					for (var i = 0; i < tabs.length; i++) {
+						var expectedNumText = expectedNum[categories[i].key] !== 0 ? ` (${expectedNum[categories[i].key]})` : '';
+						assert.equal(tabs[i].text, `${categories[i].title}${expectedNumText}`);
 					}
-				}
-				done();
+					done();
+				});
 			});
-		});
-		test('removing filter category updates filters', function() {
-			var expected = _getExpectedAndImport(filter);
-			var removal = categories[0].key;
-			filter.removeFilterCategory(removal);
-			expected = expected.filter(e => e.key !== removal);
-			assert.deepEqual(expected, filter._filters);
-		});
-		test('removing filter option updates filters', function() {
-			var expected = _getExpectedAndImport(filter);
-			var removal = [options[1].cat, options[1].key];
-			filter.removeFilterOption(removal[0], removal[1]);
-			var cat = expected.filter(e => e.key === removal[0])[0];
-			cat.options = cat.options.filter(o => o.key !== removal[1]);
-			assert.deepEqual(expected, filter._filters);
-		});
-		test('removing filter category updates display', function(done) {
-			_getExpectedAndImport(filter);
-			var removal = categories[0].key;
-			filter.removeFilterCategory(removal);
-			window.requestAnimationFrame(function() {
-				var headers = _getTabPanels();
-				assert.equal(categories.length - 1, headers.length);
-				assert.deepEqual(categories.filter(c => c.key !== removal).map(c => c.title), [].map.call(headers, h => h.text));
-				done();
+			test('total filter count is not shown when no options are selected', function(done) {
+				_getExpectedAndImport(filter);
+				window.requestAnimationFrame(function() {
+					var totalCount = _getDropdownOpener();
+					assert.equal('Filter', totalCount.text);
+					done();
+				});
 			});
-		});
-		test('removing filter option updates display', function(done) {
-			var expected = _getExpectedAndImport(filter);
-			var removal = [options[1].cat, options[1].key];
-			filter.removeFilterOption(removal[0], removal[1]);
-			var cat = expected.filter(e => e.key === removal[0])[0];
-			cat.options = cat.options.filter(o => o.key !== removal[1]);
-			window.requestAnimationFrame(function() {
-				var pages = _getPages();
-				for (var i = 0; i < pages.length; i++) {
-					var pCat = expected.filter(e => e.key === pages[i].parentKey)[0];
-					var opts = _getOptions(pages[i]);
-					assert.deepEqual(pCat.options.map(o => o.title), [].map.call(opts, o => o.text));
-				}
-				done();
+			test('total filter count is displayed correctly when one option is selected', function(done) {
+				_setSelectedOptions([2]);
+				_getExpectedAndImport(filter);
+				window.requestAnimationFrame(function() {
+					var totalCount = _getDropdownOpener();
+					assert.equal('Filter: 1 Filter', totalCount.text);
+					done();
+				});
 			});
-		});
-		test('updating filter option updates filters', function() {
-			const update = 2;
-			_setSelectedOptions([0, 4, 5]);
-			const expected = _getExpectedAndImport(filter);
-			filter.updateFilterOptionSelectedStatus(options[update].cat, options[update].key, true);
-			_updateExpectedOption(update, true, '', expected);
-			assert.deepEqual(expected, filter._filters);
-		});
-		test('updating filter option updates display', function(done) {
-			const update = 2;
-			const selected = [0, 4, 5];
-			_setSelectedOptions(selected);
-			const expected = _getExpectedAndImport(filter);
-			filter.updateFilterOptionSelectedStatus(options[update].cat, options[update].key, true);
-			_updateExpectedOption(update, true, '', expected);
-			window.requestAnimationFrame(function() {
-				var pages = _getPages();
-				for (var i = 0; i < pages.length; i++) {
-					var opts = _getOptions(pages[i]);
-					assert.equal(pages[i].options.length, opts.length);
-					for (var j = 0; j < opts.length; j++) {
-						assert.equal (opts[j].selected, expected[i].options[j].selected);
+			test('total filter count is displayed correctly when multiple options are selected', function(done) {
+				var selected = [0, 4, 5];
+				_setSelectedOptions(selected);
+				_getExpectedAndImport(filter);
+				window.requestAnimationFrame(function() {
+					var totalCount = _getDropdownOpener();
+					assert.equal(`Filter: ${selected.length} Filters`, totalCount.text);
+					done();
+				});
+			});
+			test('filter categories display correctly', function(done) {
+				_getExpectedAndImport(filter);
+				window.requestAnimationFrame(function() {
+					var headers = _getTabPanels();
+					assert.equal(filter._filters.length, headers.length);
+					for (var i = 0; i < headers.length; i++) {
+						assert.equal(filter._filters[i].title, headers[i].text);
 					}
-				}
-				done();
+					done();
+				});
 			});
-		});
-		test('adding duplicate filter option updates filters', function() {
-			const update = 2;
-			const newTitle = 'newTitle';
-			_setSelectedOptions([0, 4, 5]);
-			const expected = _getExpectedAndImport(filter);
-			filter.addFilterOption(options[update].cat, options[update].key, newTitle, true);
-			_updateExpectedOption(update, true, newTitle, expected);
-			assert.deepEqual(expected, filter._filters);
-		});
-		test('adding duplicate filter option updates display', function(done) {
-			const update = 2;
-			const newTitle = 'newTitle';
-			const selected = [0, 4, 5];
-			_setSelectedOptions(selected);
-			const expected = _getExpectedAndImport(filter);
-			filter.addFilterOption(options[update].cat, options[update].key, 'newTitle', true);
-			_updateExpectedOption(update, true, newTitle, expected);
-			window.requestAnimationFrame(function() {
-				var pages = _getPages();
-				for (var i = 0; i < pages.length; i++) {
-					var opts = _getOptions(pages[i]);
-					assert.equal(pages[i].options.length, opts.length);
-					for (var j = 0; j < opts.length; j++) {
-						assert.equal (opts[j].selected, expected[i].options[j].selected);
-						assert.equal(opts[j].text, expected[i].options[j].title);
+			test('filter options display correctly', function(done) {
+				_getExpectedAndImport(filter);
+				window.requestAnimationFrame(function() {
+					var pages = _getPages();
+					for (var i = 0; i < pages.length; i++) {
+						var opts = _getOptions(pages[i]);
+						assert.equal(pages[i].options.length, opts.length);
+						for (var j = 0; j < opts.length; j++) {
+							assert.equal(pages[i].options[j].title, opts[j].text);
+						}
 					}
-				}
-				done();
+					done();
+				});
+			});
+			test('removing filter category updates filters', function() {
+				var expected = _getExpectedAndImport(filter);
+				var removal = categories[0].key;
+				filter.removeFilterCategory(removal);
+				expected = expected.filter(e => e.key !== removal);
+				assert.deepEqual(expected, filter._filters);
+			});
+			test('removing filter option updates filters', function() {
+				var expected = _getExpectedAndImport(filter);
+				var removal = [options[1].cat, options[1].key];
+				filter.removeFilterOption(removal[0], removal[1]);
+				var cat = expected.filter(e => e.key === removal[0])[0];
+				cat.options = cat.options.filter(o => o.key !== removal[1]);
+				assert.deepEqual(expected, filter._filters);
+			});
+			test('removing filter category updates display', function(done) {
+				_getExpectedAndImport(filter);
+				var removal = categories[0].key;
+				filter.removeFilterCategory(removal);
+				window.requestAnimationFrame(function() {
+					var headers = _getTabPanels();
+					assert.equal(categories.length - 1, headers.length);
+					assert.deepEqual(categories.filter(c => c.key !== removal).map(c => c.title), [].map.call(headers, h => h.text));
+					done();
+				});
+			});
+			test('removing filter option updates display', function(done) {
+				var expected = _getExpectedAndImport(filter);
+				var removal = [options[1].cat, options[1].key];
+				filter.removeFilterOption(removal[0], removal[1]);
+				var cat = expected.filter(e => e.key === removal[0])[0];
+				cat.options = cat.options.filter(o => o.key !== removal[1]);
+				window.requestAnimationFrame(function() {
+					var pages = _getPages();
+					for (var i = 0; i < pages.length; i++) {
+						var pCat = expected.filter(e => e.key === pages[i].parentKey)[0];
+						var opts = _getOptions(pages[i]);
+						assert.deepEqual(pCat.options.map(o => o.title), [].map.call(opts, o => o.text));
+					}
+					done();
+				});
+			});
+			test('updating filter option updates filters', function() {
+				const update = 2;
+				_setSelectedOptions([0, 4, 5]);
+				const expected = _getExpectedAndImport(filter);
+				filter.updateFilterOptionSelectedStatus(options[update].cat, options[update].key, true);
+				_updateExpectedOption(update, true, '', expected);
+				assert.deepEqual(expected, filter._filters);
+			});
+			test('updating filter option updates display', function(done) {
+				const update = 2;
+				const selected = [0, 4, 5];
+				_setSelectedOptions(selected);
+				const expected = _getExpectedAndImport(filter);
+				filter.updateFilterOptionSelectedStatus(options[update].cat, options[update].key, true);
+				_updateExpectedOption(update, true, '', expected);
+				window.requestAnimationFrame(function() {
+					var pages = _getPages();
+					for (var i = 0; i < pages.length; i++) {
+						var opts = _getOptions(pages[i]);
+						assert.equal(pages[i].options.length, opts.length);
+						for (var j = 0; j < opts.length; j++) {
+							assert.equal (opts[j].selected, expected[i].options[j].selected);
+						}
+					}
+					done();
+				});
+			});
+			test('adding duplicate filter option updates filters', function() {
+				const update = 2;
+				const newTitle = 'newTitle';
+				_setSelectedOptions([0, 4, 5]);
+				const expected = _getExpectedAndImport(filter);
+				filter.addFilterOption(options[update].cat, options[update].key, newTitle, true);
+				_updateExpectedOption(update, true, newTitle, expected);
+				assert.deepEqual(expected, filter._filters);
+			});
+			test('adding duplicate filter option updates display', function(done) {
+				const update = 2;
+				const newTitle = 'newTitle';
+				const selected = [0, 4, 5];
+				_setSelectedOptions(selected);
+				const expected = _getExpectedAndImport(filter);
+				filter.addFilterOption(options[update].cat, options[update].key, 'newTitle', true);
+				_updateExpectedOption(update, true, newTitle, expected);
+				window.requestAnimationFrame(function() {
+					var pages = _getPages();
+					for (var i = 0; i < pages.length; i++) {
+						var opts = _getOptions(pages[i]);
+						assert.equal(pages[i].options.length, opts.length);
+						for (var j = 0; j < opts.length; j++) {
+							assert.equal (opts[j].selected, expected[i].options[j].selected);
+							assert.equal(opts[j].text, expected[i].options[j].title);
+						}
+					}
+					done();
+				});
 			});
 		});
 	});
@@ -345,8 +386,6 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 				const input = pageFixture.shadowRoot.querySelector('d2l-input-search');
 				input.value = search;
 				const button = input.shadowRoot.querySelector('.d2l-input-search-search');
-				console.log(input);
-				console.log(button);
 				afterNextRender(button, b => {
 					MockInteractions.tap(b);
 				}, [button]);

--- a/test/d2l-filter-dropdown/d2l-filter-dropdown.js
+++ b/test/d2l-filter-dropdown/d2l-filter-dropdown.js
@@ -223,26 +223,6 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 				done();
 			});
 		});
-		test('changing search input updates option display', function(done) {
-			_getExpectedAndImport(filter);
-			window.requestAnimationFrame(function() {
-				var pages = _getPages();
-				var search = options[1].title.substr(-1);
-				var searchInput = pages[0].shadowRoot.querySelector('d2l-input-search');
-				searchInput.value = search;
-				var searchButton = searchInput.shadowRoot.querySelector('.d2l-input-search-search');
-				afterNextRender(searchButton, function(button) {
-					MockInteractions.tap(button);
-					requestAnimationFrame(function() {
-						var opts = _getOptions(pages[0]);
-						for (var i = 0; i < opts.length; i++) {
-							assert.equal(opts[i].text.indexOf(search) === -1, opts[i].hidden || false);
-						}
-						done();
-					});
-				}, [searchButton]);
-			});
-		});
 		test('removing filter category updates filters', function() {
 			var expected = _getExpectedAndImport(filter);
 			var removal = categories[0].key;
@@ -347,21 +327,30 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 		setup(function() {
 			pageFixture = fixture('page');
 		});
-		test('contains returns true when substring exists', function() {
-			const found = pageFixture._caseInsensitiveContainsSubstring('Hello World', 'Hello');
-			assert.equal(true, found);
-		});
-		test('contains returns false when substring doesn\'t exist', function() {
-			const found = pageFixture._caseInsensitiveContainsSubstring('Hello World', 'HelloWorld');
-			assert.equal(false, found);
-		});
-		test('contains returns true when substring exists, regardless of case', function() {
-			const found = pageFixture._caseInsensitiveContainsSubstring('Hello World', 'hello');
-			assert.equal(true, found);
-		});
-		test('contains can handle special characters', function() {
-			const found = pageFixture._caseInsensitiveContainsSubstring('Hello World-/\\^$*+?.()|[]{}', 'world-/\\^$*+?.()|[]{}');
-			assert.equal(true, found);
+
+		test('searching emits event with correct context', (done) => {
+			const search = 'abc123';
+			const key = 'this is a key';
+			pageFixture.parentKey = key;
+
+			pageFixture.addEventListener('d2l-filter-dropdown-page-searched', (e) => {
+				expect(e.composed).to.be.true;
+				expect(e.bubbles).to.be.true;
+				expect(e.detail.value).to.equal(search);
+				expect(e.detail.categoryKey).to.equal(key);
+				done();
+			});
+
+			window.requestAnimationFrame(() => {
+				const input = pageFixture.shadowRoot.querySelector('d2l-input-search');
+				input.value = search;
+				const button = input.shadowRoot.querySelector('.d2l-input-search-search');
+				console.log(input);
+				console.log(button);
+				afterNextRender(button, b => {
+					MockInteractions.tap(b);
+				}, [button]);
+			});
 		});
 	});
 


### PR DESCRIPTION
This PR moves searching out of this component. Instead this component will emit an event, allowing parent components to handle search however they choose.

This is the first step to allow us to search server-side and it also unblocks pagination for filters.

Paired with: https://github.com/BrightspaceHypermediaComponents/common/pull/17