### PR TITLE
Fix automatic CI versioning on cron builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
     npm run test:polymer:local || travis_terminate 1;
   fi
 - |
-  if [ "$TRAVIS_BRANCH" == "master" ] && [ $TRAVIS_PULL_REQUEST == false ]; then
+  if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == false ] && [ $TRAVIS_EVENT_TYPE != "cron" ]; then
     echo "Not a Pull Request and on branch master so bumping version";
     frauci-update-version;
     export TRAVIS_TAG=$(frauci-get-version)


### PR DESCRIPTION
Updates travis.yml to check $TRAVIS_EVENT_TYPE and skip version bump if it is a cron