### PR TITLE
Add properties to set header and opener langterms

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ Then, add the `d2l-filter-dropdown` as the top level filter component.  For each
 </d2l-filter-dropdown>
 ```
 
+The default lang terms can be overidden by setting the appropriate attributes.
+
+```html
+<d2l-filter-dropdown total-selected-option-count="3" header-text="Send To" opener-text="Send" opener-single="Sending To One" opener-multiple="Sending To Many">
+	<d2l-filter-dropdown-category key="1" category-text="Category 1" selected-option-count="1">
+		<d2l-menu-item-checkbox selected text="Option 1 - 1" value="1"></d2l-menu-item-checkbox>
+		<d2l-menu-item-checkbox text="Option 1 - 2" value="2"></d2l-menu-item-checkbox>
+	</d2l-filter-dropdown-category>
+</d2l-filter-dropdown>
+```
+
 #### Attributes
 
 `d2l-filter-dropdown`:
@@ -59,6 +70,13 @@ Then, add the `d2l-filter-dropdown` as the top level filter component.  For each
 - `max-width` (optional): Sets the max-width of the filter dropdown.
 - `min-width` (optional): Sets the min-width of the filter dropdown.
 - `total-selected-option-count`: The total number of selected filter options across all categories.  When options are selected and de-selected, the consumer is responsible for updating this number after updating its own data store.
+- `header-text` (optional): Sets the text for the filter content header.
+- `opener-text` (optional): Sets the text for the opener when there are no selections.
+- `opener-single` (optional): Sets the text for the opener when there is a single selection.
+- `opener-multiple` (optional): Sets the text for the opener when there are multiple selections.
+- `disable-opener-text-variation` (optional): Disables displaying different text for different number of selections, instead always displaying the term for no selections.
+
+Note that for the header and opener text overrides, if the terms are to reflect the number of selections (e.g. `Sending To 3 Selections`), the consumer is responsible for updating those terms when the number of selections change.
 
 `d2l-filter-dropdown-category`:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Then, add the `d2l-filter-dropdown` as the top level filter component.  For each
 The default lang terms can be overidden by setting the appropriate attributes.
 
 ```html
-<d2l-filter-dropdown total-selected-option-count="3" header-text="Send To" opener-text="Send" opener-single="Sending To One" opener-multiple="Sending To Many">
+<d2l-filter-dropdown total-selected-option-count="3" header-text="Send To" opener-text="Send" opener-text-single="Sending To One" opener-text-multiple="Sending To Many">
 	<d2l-filter-dropdown-category key="1" category-text="Category 1" selected-option-count="1">
 		<d2l-menu-item-checkbox selected text="Option 1 - 1" value="1"></d2l-menu-item-checkbox>
 		<d2l-menu-item-checkbox text="Option 1 - 2" value="2"></d2l-menu-item-checkbox>
@@ -72,8 +72,8 @@ The default lang terms can be overidden by setting the appropriate attributes.
 - `total-selected-option-count`: The total number of selected filter options across all categories.  When options are selected and de-selected, the consumer is responsible for updating this number after updating its own data store.
 - `header-text` (optional): Sets the text for the filter content header.
 - `opener-text` (optional): Sets the text for the opener when there are no selections.
-- `opener-single` (optional): Sets the text for the opener when there is a single selection.
-- `opener-multiple` (optional): Sets the text for the opener when there are multiple selections.
+- `opener-text-single` (optional): Sets the text for the opener when there is a single selection.
+- `opener-text-multiple` (optional): Sets the text for the opener when there are multiple selections.
 - `disable-opener-text-variation` (optional): Disables displaying different text for different number of selections, instead always displaying the term for no selections.
 
 Note that for the header and opener text overrides, if the terms are to reflect the number of selections (e.g. `Sending To 3 Selections`), the consumer is responsible for updating those terms when the number of selections change.

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown.js
@@ -33,7 +33,7 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 					display: none;
 				}
 			</style>
-			<d2l-dropdown-button-subtle text="[[_getOpenerText(totalSelectedOptionCount, disableOpenerTextVariation, openerText, openerSingle, openerMultiple)]]">
+			<d2l-dropdown-button-subtle text="[[_getOpenerText(totalSelectedOptionCount, disableOpenerTextVariation, openerText, openerTextSingle, openerTextMultiple)]]">
 				<d2l-dropdown-tabs
 					min-width="[[minWidth]]"
 					max-width="[[maxWidth]]"
@@ -73,11 +73,11 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 				type: String,
 				value: ''
 			},
-			openerSingle: {
+			openerTextSingle: {
 				type: String,
 				value: ''
 			},
-			openerMultiple: {
+			openerTextMultiple: {
 				type: String,
 				value: ''
 			},
@@ -121,14 +121,14 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 		);
 	}
 
-	_getOpenerText(totalSelectedOptionCount, disableOpenerTextVariation, openerText, openerSingle, openerMultiple) {
+	_getOpenerText(totalSelectedOptionCount, disableOpenerTextVariation, openerText, openerTextSingle, openerTextMultiple) {
 		if (totalSelectedOptionCount === 0 || disableOpenerTextVariation) {
 			return this._localizeOrAlt(openerText, 'filter');
 		}
 		if (totalSelectedOptionCount === 1) {
-			return this._localizeOrAlt(openerSingle, 'filterSingle');
+			return this._localizeOrAlt(openerTextSingle, 'filterSingle');
 		}
-		return this._localizeOrAlt(openerMultiple, 'filterMultiple', 'numOptions', totalSelectedOptionCount);
+		return this._localizeOrAlt(openerTextMultiple, 'filterMultiple', 'numOptions', totalSelectedOptionCount);
 	}
 
 	_localizeOrAlt(altText, ...args) {

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown.js
@@ -33,14 +33,14 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 					display: none;
 				}
 			</style>
-			<d2l-dropdown-button-subtle text="[[_getOpenerText(totalSelectedOptionCount)]]">
+			<d2l-dropdown-button-subtle text="[[_getOpenerText(totalSelectedOptionCount, disableOpenerTextVariation, openerText, openerSingle, openerMultiple)]]">
 				<d2l-dropdown-tabs
 					min-width="[[minWidth]]"
 					max-width="[[maxWidth]]"
 					no-padding
 					render-content>
 					<div class="d2l-filter-dropdown-content-header">
-						<span>[[localize('filterBy')]]</span>
+						<span>[[_localizeOrAlt(headerText, 'filterBy')]]</span>
 						<d2l-button-subtle text="[[localize('clear')]]" hidden$="[[!totalSelectedOptionCount]]" on-click="_clearFilters"></d2l-button-subtle>
 					</div>
 					<d2l-tabs>
@@ -64,6 +64,26 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 			totalSelectedOptionCount: {
 				type: Number,
 				value: 0
+			},
+			headerText: {
+				type: String,
+				value: ''
+			},
+			openerText: {
+				type: String,
+				value: ''
+			},
+			openerSingle: {
+				type: String,
+				value: ''
+			},
+			openerMultiple: {
+				type: String,
+				value: ''
+			},
+			disableOpenerTextVariation: {
+				type: Boolean,
+				value: false
 			}
 		};
 	}
@@ -101,14 +121,18 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 		);
 	}
 
-	_getOpenerText(totalSelectedOptionCount) {
-		if (totalSelectedOptionCount === 0) {
-			return this.localize('filter');
+	_getOpenerText(totalSelectedOptionCount, disableOpenerTextVariation, openerText, openerSingle, openerMultiple) {
+		if (totalSelectedOptionCount === 0 || disableOpenerTextVariation) {
+			return this._localizeOrAlt(openerText, 'filter');
 		}
 		if (totalSelectedOptionCount === 1) {
-			return this.localize('filterSingle');
+			return this._localizeOrAlt(openerSingle, 'filterSingle');
 		}
-		return this.localize('filterMultiple', 'numOptions', totalSelectedOptionCount);
+		return this._localizeOrAlt(openerMultiple, 'filterMultiple', 'numOptions', totalSelectedOptionCount);
+	}
+
+	_localizeOrAlt(altText, ...args) {
+		return altText ? altText : this.localize(...args);
 	}
 }
 

--- a/test/d2l-filter-dropdown/d2l-filter-dropdown.html
+++ b/test/d2l-filter-dropdown/d2l-filter-dropdown.html
@@ -35,7 +35,7 @@
 
 		<test-fixture id="text-override">
 			<template strip-whitespace>
-				<d2l-filter-dropdown total-selected-option-count="2" header-text="Send To" opener-text="Sending To None" opener-single="Sending To One" opener-multiple="Sending To Many">
+				<d2l-filter-dropdown total-selected-option-count="2" header-text="Send To" opener-text="Sending To None" opener-text-single="Sending To One" opener-text-multiple="Sending To Many">
 					<d2l-filter-dropdown-category key="1" category-text="Category 1" selected-option-count="2">
 						<d2l-menu-item-checkbox selected text="Option 1 - 1" value="1"></d2l-menu-item-checkbox>
 						<d2l-menu-item-checkbox text="Option 1 - 2" value="2"></d2l-menu-item-checkbox>

--- a/test/d2l-filter-dropdown/d2l-filter-dropdown.html
+++ b/test/d2l-filter-dropdown/d2l-filter-dropdown.html
@@ -33,6 +33,30 @@
 			</template>
 		</test-fixture>
 
+		<test-fixture id="text-override">
+			<template strip-whitespace>
+				<d2l-filter-dropdown total-selected-option-count="2" header-text="Send To" opener-text="Sending To None" opener-single="Sending To One" opener-multiple="Sending To Many">
+					<d2l-filter-dropdown-category key="1" category-text="Category 1" selected-option-count="2">
+						<d2l-menu-item-checkbox selected text="Option 1 - 1" value="1"></d2l-menu-item-checkbox>
+						<d2l-menu-item-checkbox text="Option 1 - 2" value="2"></d2l-menu-item-checkbox>
+						<d2l-menu-item-checkbox selected text="Option 1 - 3" value="3"></d2l-menu-item-checkbox>
+					</d2l-filter-dropdown-category>
+				</d2l-filter-dropdown>
+			</template>
+		</test-fixture>
+
+		<test-fixture id="text-variation-disabled">
+			<template strip-whitespace>
+				<d2l-filter-dropdown total-selected-option-count="2" disable-opener-text-variation>
+					<d2l-filter-dropdown-category key="1" category-text="Category 1" selected-option-count="2">
+						<d2l-menu-item-checkbox selected text="Option 1 - 1" value="1"></d2l-menu-item-checkbox>
+						<d2l-menu-item-checkbox text="Option 1 - 2" value="2"></d2l-menu-item-checkbox>
+						<d2l-menu-item-checkbox selected text="Option 1 - 3" value="3"></d2l-menu-item-checkbox>
+					</d2l-filter-dropdown-category>
+				</d2l-filter-dropdown>
+			</template>
+		</test-fixture>
+
 		<script type="module">
 			import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
@@ -105,6 +129,33 @@
 					}
 
 					getTabs();
+				});
+
+				test('the text values can be overridden', function() {
+					filter = fixture('text-override');
+					var header = filter.shadowRoot.querySelector('.d2l-filter-dropdown-content-header span');
+					assert.equal(header.innerText, 'Send To');
+
+					var openerButton = filter.shadowRoot.querySelector('d2l-dropdown-button-subtle');
+					assert.equal(openerButton.text, 'Sending To Many');
+
+					filter.totalSelectedOptionCount = 1;
+					assert.equal(openerButton.text, 'Sending To One');
+
+					filter.totalSelectedOptionCount = 0;
+					assert.equal(openerButton.text, 'Sending To None');
+				});
+
+				test('the opener text variations can be disabled', function() {
+					filter = fixture('text-variation-disabled');
+					var openerButton = filter.shadowRoot.querySelector('d2l-dropdown-button-subtle');
+					assert.equal(openerButton.text, 'Filter');
+
+					filter.totalSelectedOptionCount = 1;
+					assert.equal(openerButton.text, 'Filter');
+
+					filter.totalSelectedOptionCount = 0;
+					assert.equal(openerButton.text, 'Filter');
 				});
 			});
 		</script>


### PR DESCRIPTION
We're using `d2l-filter-dropdown` in Activity Feed and are loving it. However, we are also using it as a `Send To` selector, for which we to modify the terminology a little. We also don't have a need to display how many selections have been made in the opener button, as we're displaying tags alongside it which show exactly which selections have been made.

This PR introduces new properties that allow the consumer to provide their own alternative terms for
- `filterBy` by setting the property `headerText`
- `filter` by setting the property `openerText`
- `filterSingle` by setting the property `openerSingle`
- `filterMultiple` by setting the property `openerMultiple`

as well as the option to disable displaying different terms for different number of selections on the opener button via `disable-opener-text-variation`.