### PR TITLE
Set focus on opener button when focusing on component

### DIFF
--- a/components/d2l-filter-dropdown/d2l-filter-dropdown.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown.js
@@ -134,6 +134,10 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 	_localizeOrAlt(altText, ...args) {
 		return altText ? altText : this.localize(...args);
 	}
+
+	focus() {
+		this.shadowRoot.querySelector('d2l-dropdown-button-subtle').focus();
+	}
 }
 
 window.customElements.define(D2LFilterDropdown.is, D2LFilterDropdown);

--- a/test/d2l-filter-dropdown/d2l-filter-dropdown.html
+++ b/test/d2l-filter-dropdown/d2l-filter-dropdown.html
@@ -130,7 +130,11 @@
 
 					getTabs();
 				});
-
+				test('focussing the filter sets the focus on the opener button', function() {
+					assert.equal(filter.shadowRoot.activeElement, null);
+					filter.focus();
+					assert.equal(filter.shadowRoot.activeElement.tagName.toLowerCase(), 'd2l-dropdown-button-subtle');
+				});
 				test('the text values can be overridden', function() {
 					filter = fixture('text-override');
 					var header = filter.shadowRoot.querySelector('.d2l-filter-dropdown-content-header span');


### PR DESCRIPTION
We would like to be able to programmatically set the focus on opener button, so we need to pass the focus to the `d2l-dropdown-button-subtle` opener when focusing on `d2l-filter-dropdown`.