### PR TITLE
allow no update of option checked state

### DIFF
--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js
@@ -31,6 +31,10 @@ Polymer({
 		'role': 'menuitemcheckbox'
 	},
 
+	properties: {
+		noUpdate: Boolean
+	},
+
 	attached: function() {
 		afterNextRender(this, function() {
 			this.listen(this, 'd2l-menu-item-select', '_onSelect');
@@ -42,7 +46,9 @@ Polymer({
 	},
 
 	_onSelect: function(e) {
-		this.set('selected', !this.selected);
+		if (!this.noUpdate) {
+			this.set('selected', !this.selected);
+		}
 		this.__onSelect(e);
 	}
 

--- a/test/d2l-filter-dropdown/d2l-filter-dropdown.html
+++ b/test/d2l-filter-dropdown/d2l-filter-dropdown.html
@@ -108,13 +108,15 @@
 				});
 				test('the opener text is set accordingly', function() {
 					var openerButton = filter.shadowRoot.querySelector('d2l-dropdown-button-subtle');
-					assert.equal(openerButton.text, 'Filter: 3 Filters');
+					requestAnimationFrame(function() {
+						assert.equal(openerButton.text, 'Filter: 3 Filters');
 
-					filter.totalSelectedOptionCount = 1;
-					assert.equal(openerButton.text, 'Filter: 1 Filter');
+						filter.totalSelectedOptionCount = 1;
+						assert.equal(openerButton.text, 'Filter: 1 Filter');
 
-					filter.totalSelectedOptionCount = 0;
-					assert.equal(openerButton.text, 'Filter');
+						filter.totalSelectedOptionCount = 0;
+						assert.equal(openerButton.text, 'Filter');
+					});
 				});
 				test('filter categories display correctly', function(done) {
 					function getTabs() {

--- a/test/d2l-filter-dropdown/d2l-filter-dropdown.html
+++ b/test/d2l-filter-dropdown/d2l-filter-dropdown.html
@@ -108,14 +108,16 @@
 				});
 				test('the opener text is set accordingly', function() {
 					var openerButton = filter.shadowRoot.querySelector('d2l-dropdown-button-subtle');
-					requestAnimationFrame(function() {
+					afterNextRender(filter, function() {
 						assert.equal(openerButton.text, 'Filter: 3 Filters');
-
 						filter.totalSelectedOptionCount = 1;
-						assert.equal(openerButton.text, 'Filter: 1 Filter');
-
-						filter.totalSelectedOptionCount = 0;
-						assert.equal(openerButton.text, 'Filter');
+						afterNextRender(filter, function() {
+							assert.equal(openerButton.text, 'Filter: 1 Filter');
+							filter.totalSelectedOptionCount = 0;
+							afterNextRender(filter, function() {
+								assert.equal(openerButton.text, 'Filter');
+							});
+						});
 					});
 				});
 				test('filter categories display correctly', function(done) {


### PR DESCRIPTION
To allow `d2l-filter-dropdown-option` to not update the checked state automatically, instead allowing consumer to set `selected` explicitly. This allows consumer components to not uncheck a menu item when it is clicked multiple times (use case is when one item must always be ckecked).