### PR TITLE
Call _dispatchSelected on behavior.

### DIFF
--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
@@ -137,6 +137,7 @@ class D2LFilterDropdownCategory extends mixinBehaviors([D2L.PolymerBehaviors.Tab
 	}
 
 	_dispatchSelected() {
+		super._dispatchSelected();
 		this.dispatchEvent(
 			new CustomEvent(
 				'd2l-filter-dropdown-category-selected',


### PR DESCRIPTION
The Lit version of `d2l-tabs` relies on the event that is dispatched by the behavior's method.  Previously, the Polymer component had some redundancy for setting the state of the tab, which is why this was not a problem previously.