### PR TITLE
Switch things to core

### DIFF
--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
@@ -1,164 +1,207 @@
-import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/inputs/input-search.js';
 import '@brightspace-ui/core/components/menu/menu.js';
-import 'd2l-tabs/d2l-tab-panel-behavior.js';
-import './d2l-filter-dropdown-localize-behavior.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { LocalizeStaticMixin } from '@brightspace-ui/core/mixins/localize-static-mixin.js';
+import { TabPanelMixin } from '@brightspace-ui/core/components/tabs/tab-panel-mixin.js';
 
-/**
- * @customElement
- * @polymer
- */
+class FilterDropdownCategory extends LocalizeStaticMixin(TabPanelMixin(LitElement)) {
 
-class D2LFilterDropdownCategory extends mixinBehaviors([D2L.PolymerBehaviors.Tabs.TabPanelBehavior, D2L.PolymerBehaviors.FilterDropdown.LocalizeBehavior], PolymerElement) {
-	static get template() {
+	static get properties() {
+		return {
+			categoryText: { type: String, attribute: 'category-text' },
+			disableSearch: { type: Boolean, attribute: 'disable-search' },
+			key: { type: String },
+			searchValue: { type: String, attribute: 'search-value' },
+			selectedOptionCount: { type: Number, attribute: 'selected-option-count' }
+		};
+	}
+
+	static get styles() {
+		return [super.styles, css`
+			:host {
+				margin: -1px -1rem 0 -1rem;
+				border-top: 1px solid var(--d2l-color-gypsum);
+				padding: 1.2rem 1rem 0 1rem;
+			}
+			.d2l-filter-dropdown-page-search {
+				margin-bottom: 0.5rem;
+			}
+			d2l-menu {
+				margin: 0 -1rem;
+				width: auto;
+			}
+		`];
+	}
+
+	static get resources() {
+		return {
+			'ar': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: 'البحث عن {category}'
+			},
+			'de': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: 'Nach {category} suchen'
+			},
+			'en': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: 'Search by {category}'
+			},
+			'es': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: 'Buscar por {category}'
+			},
+			'fi': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: 'Hakuperuste {category}'
+			},
+			'fr': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: 'Recherche par {category}'
+			},
+			'ja': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: '{category} で検索'
+			},
+			'ko': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: '{category} 필터로 검색'
+			},
+			'nb': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: 'Søk etter {category}'
+			},
+			'nl': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: 'Zoeken op {category}'
+			},
+			'pt': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: 'Pesquisar por {category}'
+			},
+			'sv': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: 'Sök per {category}'
+			},
+			'tr': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: '{category} Kullanarak Ara'
+			},
+			'zh': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: '按 {category} 搜索'
+			},
+			'zh-tw': {
+				categoryTitleMultiple: '{title} ({numSelected})',
+				searchBy: '依 {category} 搜尋'
+			}
+		};
+	}
+
+	constructor() {
+		super();
+		this.categoryText = '';
+		this.disableSearch = false;
+		this.key = '';
+		this.selectedOptionCount = 0;
+	}
+
+	get categoryText() {
+		return this._categoryText;
+	}
+
+	set categoryText(val) {
+		const oldVal = this._categoryText;
+		if (oldVal !== val) {
+			this._categoryText = val;
+			this.requestUpdate().then(() => {
+				this._updateTabText(this._categoryText, this.selectedOptionCount);
+			});
+		}
+	}
+
+	get selectedOptionCount() {
+		return this._selectedOptionCount;
+	}
+
+	set selectedOptionCount(val) {
+		const oldVal = this._selectedOptionCount;
+		if (oldVal !== val) {
+			this._selectedOptionCount = val;
+			this.requestUpdate().then(() => {
+				this._updateTabText(this.categoryText, this._selectedOptionCount);
+			});
+		}
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+		this.addEventListener('d2l-menu-item-select', (e) => {
+			this.selected = !this.selected;
+			this.__onSelect(e);
+		});
+	}
+
+	render() {
 		return html`
-			<style include="d2l-tab-panel-styles">
-				:host {
-					margin: -1px -1rem 0 -1rem;
-					border-top: 1px solid var(--d2l-color-gypsum);
-					padding: 1.2rem 1rem 0 1rem;
-				}
-
-				.d2l-filter-dropdown-page-search {
-					margin-bottom: 0.5rem;
-				}
-
-				d2l-menu {
-					margin: 0 -1rem;
-					width: auto;
-				}
-			</style>
-			<div class="d2l-filter-dropdown-page-search" hidden$="[[disableSearch]]">
-				<d2l-input-search placeholder="[[localize('searchBy', 'category', categoryText)]]" value="[[searchValue]]"></d2l-input-search>
+			<div class="d2l-filter-dropdown-page-search" ?hidden="${this.disableSearch}">
+				<d2l-input-search @d2l-input-search-searched="${this._handleSearchChange}"
+					placeholder="${this.localize('searchBy', 'category', this.categoryText)}"
+					value="${ifDefined(this.searchValue)}">
+				</d2l-input-search>
 			</div>
-			<d2l-menu label="[[text]]">
+			<d2l-menu @d2l-menu-item-change="${this._handleMenuItemChange}" label="${this.text}">
 				<slot></slot>
 			</d2l-menu>
 		`;
 	}
-	static get is() { return 'd2l-filter-dropdown-category'; }
-	static get properties() {
-		return {
-			key: {
-				type: String,
-				value: ''
+
+	_dispatchSelected() {
+		super._dispatchSelected();
+		this.dispatchEvent(new CustomEvent('d2l-filter-dropdown-category-selected', {
+			detail: {
+				categoryKey: this.key
 			},
-			categoryText: {
-				type: String,
-				value: ''
-			},
-			disableSearch: {
-				type: Boolean,
-				value: false
-			},
-			searchValue: {
-				type: String
-			},
-			selectedOptionCount: {
-				type: Number,
-				value: 0
-			}
-		};
-	}
-	static get observers() {
-		return [
-			'_updateTabText(categoryText, selectedOptionCount)'
-		];
-	}
-
-	ready() {
-		super.ready();
-		this._handleSearchChange = this._handleSearchChange.bind(this);
-		this._handleMenuItemChange = this._handleMenuItemChange.bind(this);
-	}
-
-	attached() {
-		afterNextRender(this, function() {
-			var menu = this._getMenu();
-			var search = this._getSearchInput();
-
-			search.addEventListener('d2l-input-search-searched', this._handleSearchChange);
-			menu.addEventListener('d2l-menu-item-change', this._handleMenuItemChange);
-		}.bind(this));
-	}
-
-	detached() {
-		var menu = this._getMenu();
-		var search = this._getSearchInput();
-
-		search.removeEventListener('d2l-input-search-searched', this._handleSearchChange);
-		menu.removeEventListener('d2l-menu-item-change', this._handleMenuItemChange);
-	}
-
-	_getSearchInput() {
-		return this.shadowRoot.querySelector('d2l-input-search');
-	}
-
-	_getMenu() {
-		return this.shadowRoot.querySelector('d2l-menu');
-	}
-
-	_handleSearchChange(e) {
-		e.stopPropagation();
-		this.dispatchEvent(
-			new CustomEvent(
-				'd2l-filter-dropdown-category-searched',
-				{
-					detail: {
-						categoryKey: this.key,
-						value: e.detail.value
-					},
-					composed: true,
-					bubbles: true
-				}
-			)
-		);
+			bubbles: true,
+			composed: true
+		}));
 	}
 
 	_handleMenuItemChange(e) {
 		e.stopPropagation();
-		this.dispatchEvent(
-			new CustomEvent(
-				'd2l-filter-dropdown-option-change',
-				{
-					detail: {
-						categoryKey: this.key,
-						menuItemKey: e.detail.value,
-						selected: e.detail.selected
-					},
-					composed: true,
-					bubbles: true
-				}
-			)
-		);
+		this.dispatchEvent(new CustomEvent('d2l-filter-dropdown-option-change', {
+			detail: {
+				categoryKey: this.key,
+				menuItemKey: e.detail.value,
+				selected: e.detail.selected
+			},
+			composed: true,
+			bubbles: true
+		}));
 	}
 
-	_dispatchSelected() {
-		super._dispatchSelected();
-		this.dispatchEvent(
-			new CustomEvent(
-				'd2l-filter-dropdown-category-selected',
-				{
-					detail: {
-						categoryKey: this.key
-					},
-					bubbles: true,
-					composed: true
-				}
-			)
-		);
+	_handleSearchChange(e) {
+		e.stopPropagation();
+		this.dispatchEvent(new CustomEvent('d2l-filter-dropdown-category-searched', {
+			detail: {
+				categoryKey: this.key,
+				value: e.detail.value
+			},
+			composed: true,
+			bubbles: true
+		}));
 	}
 
 	_updateTabText(categoryText, selectedOptionCount) {
 		if (selectedOptionCount === 0) {
-			this.text = categoryText;
+			this.setAttribute('text', categoryText);
 		} else {
-			this.text = this.localize('categoryTitleMultiple', 'title', categoryText, 'numSelected', selectedOptionCount);
+			this.setAttribute('text', this.localize('categoryTitleMultiple', 'title', categoryText, 'numSelected', selectedOptionCount));
 		}
 	}
+
 }
 
-window.customElements.define(D2LFilterDropdownCategory.is, D2LFilterDropdownCategory);
+customElements.define('d2l-filter-dropdown-category', FilterDropdownCategory);

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
@@ -1,10 +1,10 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/inputs/input-search.js';
+import '@brightspace-ui/core/components/menu/menu.js';
 import 'd2l-tabs/d2l-tab-panel-behavior.js';
-import 'd2l-inputs/d2l-input-search.js';
-import 'd2l-menu/d2l-menu.js';
-import 'd2l-colors/d2l-colors.js';
 import './d2l-filter-dropdown-localize-behavior.js';
 
 /**

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-localize-behavior.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-localize-behavior.js
@@ -1,5 +1,6 @@
 import '@polymer/polymer/polymer-legacy.js';
 import 'd2l-localize-behavior/d2l-localize-behavior.js';
+
 window.D2L = window.D2L || {};
 window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
 window.D2L.PolymerBehaviors.FilterDropdown = window.D2L.PolymerBehaviors.FilterDropdown || {};

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-localize-behavior.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-localize-behavior.js
@@ -18,139 +18,109 @@ D2L.PolymerBehaviors.FilterDropdown.LocalizeBehaviorImpl = {
 			value: function() {
 				return {
 					'ar': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: 'مسح',
 						filter: 'التصفية',
 						filterBy: 'تصفية بحسب',
 						filterMultiple: 'Filter: {numOptions} Filters',
-						filterSingle: 'التصفية: عامل تصفية واحد',
-						searchBy: 'البحث عن {category}'
+						filterSingle: 'التصفية: عامل تصفية واحد'
 					},
 					'de': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: 'Löschen',
 						filter: 'Filter',
 						filterBy: 'Filtern nach',
 						filterMultiple: 'Filter: {numOptions} Filter',
-						filterSingle: 'Filter: 1 Filter',
-						searchBy: 'Nach {category} suchen'
+						filterSingle: 'Filter: 1 Filter'
 					},
 					'en': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: 'Clear',
 						filter: 'Filter',
 						filterBy: 'Filter By',
 						filterMultiple: 'Filter: {numOptions} Filters',
-						filterSingle: 'Filter: 1 Filter',
-						searchBy: 'Search by {category}'
+						filterSingle: 'Filter: 1 Filter'
 					},
 					'es': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: 'Borrar',
 						filter: 'Filtrar',
 						filterBy: 'Filtrar por',
 						filterMultiple: 'Filtro: {numOptions} filtros',
-						filterSingle: 'Filtro: 1 filtro',
-						searchBy: 'Buscar por {category}'
+						filterSingle: 'Filtro: 1 filtro'
 					},
 					'fi': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: 'Tyhjennä',
 						filter: 'Suodatin',
 						filterBy: 'Suodatusperuste',
 						filterMultiple: 'Suodatus: {numOptions} suodatinta',
-						filterSingle: 'Suodatus: 1 suodatin',
-						searchBy: 'Hakuperuste {category}'
+						filterSingle: 'Suodatus: 1 suodatin'
 					},
 					'fr': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: 'Effacer',
 						filter: 'Filtrer',
 						filterBy: 'Filtrer par',
 						filterMultiple: 'Filtre : {numOptions} filtres',
-						filterSingle: 'Filtre : 1 filtre',
-						searchBy: 'Recherche par {category}'
+						filterSingle: 'Filtre : 1 filtre'
 					},
 					'ja': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: 'クリア',
 						filter: 'フィルタ',
 						filterBy: 'フィルタの条件',
 						filterMultiple: 'フィルタ数: {numOptions}',
-						filterSingle: 'フィルタ数: 1',
-						searchBy: '{category} で検索'
+						filterSingle: 'フィルタ数: 1'
 					},
 					'ko': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: '지우기',
 						filter: '필터',
 						filterBy: '필터링 기준',
 						filterMultiple: '필터: {numOptions}개 필터',
-						filterSingle: '필터: 1개 필터',
-						searchBy: '{category} 필터로 검색'
+						filterSingle: '필터: 1개 필터'
 					},
 					'nb': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: 'Fjern',
 						filter: 'Filter',
 						filterBy: 'Filtrer etter',
 						filterSingle: 'Filter: 1 filter',
-						filterMultiple: 'Filter: {numOptions} filtre',
-						searchBy: 'Søk etter {category}'
+						filterMultiple: 'Filter: {numOptions} filtre'
 					},
 					'nl': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: 'Wissen',
 						filter: 'Filteren',
 						filterBy: 'Filteren op',
 						filterMultiple: 'Filteren: {numOptions} filters',
-						filterSingle: 'Filteren: 1 filter',
-						searchBy: 'Zoeken op {category}'
+						filterSingle: 'Filteren: 1 filter'
 					},
 					'pt': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: 'Apagar',
 						filter: 'Filtro',
 						filterBy: 'Filtrar por',
 						filterMultiple: 'Filtrar: {numOptions} filtros',
-						filterSingle: 'Filtrar: 1 Filtro',
-						searchBy: 'Pesquisar por {category}'
+						filterSingle: 'Filtrar: 1 Filtro'
 					},
 					'sv': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: 'Rensa',
 						filter: 'Filter',
 						filterBy: 'Filtrera efter',
 						filterMultiple: 'Filter: {numOptions} filter',
-						filterSingle: 'Filter: 1 filter',
-						searchBy: 'Sök per {category}'
+						filterSingle: 'Filter: 1 filter'
 					},
 					'tr': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: 'Temizle',
 						filter: 'Filtrele',
 						filterBy: 'Filtreleme Ölçütü',
 						filterMultiple: 'Filtre: {numOptions} Filtre',
-						filterSingle: 'Filtre: 1 Filtre',
-						searchBy: '{category} Kullanarak Ara'
+						filterSingle: 'Filtre: 1 Filtre'
 					},
 					'zh': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: '清除',
 						filter: '筛选',
 						filterBy: '筛选条件',
 						filterMultiple: '筛选：{numOptions} 个筛选条件',
-						filterSingle: '筛选：1 个筛选条件',
-						searchBy: '按 {category} 搜索'
+						filterSingle: '筛选：1 个筛选条件'
 					},
 					'zh-tw': {
-						categoryTitleMultiple: '{title} ({numSelected})',
 						clear: '清除',
 						filter: '篩選',
 						filterBy: '篩選依據',
 						filterMultiple: '篩選器：{numOptions} 個篩選器',
-						filterSingle: '篩選器：1 個篩選器',
-						searchBy: '依 {category} 搜尋'
+						filterSingle: '篩選器：1 個篩選器'
 					}
 				};
 			}

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js
@@ -1,10 +1,10 @@
 import '@polymer/polymer/polymer-legacy.js';
-
-import 'd2l-icons/d2l-icons.js';
-import 'd2l-menu/d2l-menu-item-selectable-styles.js';
-import 'd2l-menu/d2l-menu-item-selectable-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+import '@brightspace-ui/core/components/icons/icon.js';
+import 'd2l-menu/d2l-menu-item-selectable-styles.js';
+import 'd2l-menu/d2l-menu-item-selectable-behavior.js';
+
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-filter-dropdown-option">
@@ -14,7 +14,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-filter-dropdown-option">
 				white-space: normal;
 			}
 		</style>
-		<d2l-icon icon="d2l-tier1:check" aria-hidden="true"></d2l-icon>
+		<d2l-icon icon="tier1:check" aria-hidden="true"></d2l-icon>
 		<span>[[text]]</span>
 	</template>
 </dom-module>`;

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js
@@ -1,49 +1,39 @@
-import '@polymer/polymer/polymer-legacy.js';
-import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import '@brightspace-ui/core/components/icons/icon.js';
-import 'd2l-menu/d2l-menu-item-selectable-styles.js';
-import 'd2l-menu/d2l-menu-item-selectable-behavior.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { MenuItemSelectableMixin } from '@brightspace-ui/core/components/menu/menu-item-selectable-mixin.js';
+import { menuItemSelectableStyles } from '@brightspace-ui/core/components/menu/menu-item-selectable-styles.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
-const $_documentContainer = document.createElement('template');
+class FilterDropdownOption extends RtlMixin(MenuItemSelectableMixin(LitElement)) {
 
-$_documentContainer.innerHTML = `<dom-module id="d2l-filter-dropdown-option">
-	<template strip-whitespace="">
-		<style include="d2l-menu-item-selectable-styles">
+	static get styles() {
+		return [menuItemSelectableStyles, css`
 			:host > span {
 				white-space: normal;
 			}
-		</style>
-		<d2l-icon icon="tier1:check" aria-hidden="true"></d2l-icon>
-		<span>[[text]]</span>
-	</template>
-</dom-module>`;
-
-document.head.appendChild($_documentContainer.content);
-Polymer({
-	is: 'd2l-filter-dropdown-option',
-
-	behaviors: [
-		D2L.PolymerBehaviors.MenuItemSelectableBehavior
-	],
-
-	hostAttributes: {
-		'role': 'menuitemcheckbox'
-	},
-
-	attached: function() {
-		afterNextRender(this, function() {
-			this.listen(this, 'd2l-menu-item-select', '_onSelect');
-		}.bind(this));
-	},
-
-	detached: function() {
-		this.unlisten(this, 'd2l-menu-item-select', '_onSelect');
-	},
-
-	_onSelect: function(e) {
-		this.set('selected', !this.selected);
-		this.__onSelect(e);
+		`];
 	}
 
-});
+	constructor() {
+		super();
+		this.role = 'menuitemcheckbox';
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+		this.addEventListener('d2l-menu-item-select', (e) => {
+			this.selected = !this.selected;
+			this.__onSelect(e);
+		});
+	}
+
+	render() {
+		return html`
+			<d2l-icon icon="tier1:check" aria-hidden="true"></d2l-icon>
+			<span>${this.text}</span>
+		`;
+	}
+
+}
+
+customElements.define('d2l-filter-dropdown-option', FilterDropdownOption);

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown.js
@@ -1,10 +1,10 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
-import 'd2l-dropdown/d2l-dropdown-button-subtle.js';
-import 'd2l-dropdown/d2l-dropdown-tabs.js';
-import 'd2l-button/d2l-button-subtle.js';
-import 'd2l-tabs/d2l-tabs.js';
-import 'd2l-colors/d2l-colors.js';
+import '@brightspace-ui/core/components/button/button-subtle.js';
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-button-subtle.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-tabs.js';
+import '@brightspace-ui/core/components/tabs/tabs.js';
 import './d2l-filter-dropdown-localize-behavior.js';
 
 /**

--- a/components/d2l-search-facets/d2l-search-facets-grouping.js
+++ b/components/d2l-search-facets/d2l-search-facets-grouping.js
@@ -1,10 +1,11 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import 'd2l-inputs/d2l-input-checkbox-spacer.js';
-import 'd2l-typography/d2l-typography-shared-styles.js';
-import 'd2l-colors/d2l-colors.js';
-import './d2l-search-facets-localize-behavior.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/inputs/input-checkbox-spacer.js';
+import 'd2l-typography/d2l-typography-shared-styles.js';
+import './d2l-search-facets-localize-behavior.js';
+
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-search-facets-grouping">
@@ -53,7 +54,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-search-facets-grouping">
 			</template>
 		</fieldset>
 	</template>
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);

--- a/components/d2l-search-facets/d2l-search-facets-localize-behavior.js
+++ b/components/d2l-search-facets/d2l-search-facets-localize-behavior.js
@@ -1,5 +1,6 @@
 import '@polymer/polymer/polymer-legacy.js';
 import 'd2l-localize-behavior/d2l-localize-behavior.js';
+
 window.D2L = window.D2L || {};
 window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
 window.D2L.PolymerBehaviors.SearchFacets = window.D2L.PolymerBehaviors.SearchFacets || {};

--- a/components/d2l-search-facets/d2l-search-facets-option.js
+++ b/components/d2l-search-facets/d2l-search-facets-option.js
@@ -1,7 +1,8 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import 'd2l-inputs/d2l-input-checkbox.js';
-import 'd2l-localize-behavior/d2l-localize-behavior.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import '@brightspace-ui/core/components/inputs/input-checkbox.js';
+import 'd2l-localize-behavior/d2l-localize-behavior.js';
+
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-search-facets-option">
@@ -13,7 +14,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-search-facets-option">
 		</style>
 		<d2l-input-checkbox checked="[[checked]]" disabled="[[disabled]]" name="[[text]]" on-change="_handleChange" class="d2l-search-facets-option-checkbox">[[_facetText]]</d2l-input-checkbox>
 	</template>
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);

--- a/components/d2l-search-facets/d2l-search-facets.js
+++ b/components/d2l-search-facets/d2l-search-facets.js
@@ -1,5 +1,6 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-search-facets">
@@ -11,7 +12,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-search-facets">
 		</style>
 		<slot></slot>
 	</template>
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);

--- a/components/d2l-search-results-count/d2l-search-results-count-localize-behavior.js
+++ b/components/d2l-search-results-count/d2l-search-results-count-localize-behavior.js
@@ -1,4 +1,5 @@
 import 'd2l-localize-behavior/d2l-localize-behavior.js';
+
 window.D2L = window.D2L || {};
 window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
 window.D2L.PolymerBehaviors.SearchResultsCount = window.D2L.PolymerBehaviors.SearchResultsCount || {};

--- a/components/d2l-search-results-count/d2l-search-results-count.js
+++ b/components/d2l-search-results-count/d2l-search-results-count.js
@@ -1,6 +1,7 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import './d2l-search-results-count-localize-behavior.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import './d2l-search-results-count-localize-behavior.js';
+
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-search-results-count">
@@ -14,7 +15,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-search-results-count">
 		</style>
 		[[_text]]
 	</template>
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);

--- a/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-localize-behavior.js
+++ b/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-localize-behavior.js
@@ -1,5 +1,6 @@
 import '@polymer/polymer/polymer-legacy.js';
 import 'd2l-localize-behavior/d2l-localize-behavior.js';
+
 window.D2L = window.D2L || {};
 window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
 window.D2L.PolymerBehaviors.SortByDropdown = window.D2L.PolymerBehaviors.SortByDropdown || {};

--- a/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js
+++ b/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js
@@ -1,9 +1,9 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import '@brightspace-ui/core/components/icons/icon.js';
 import 'd2l-menu/d2l-menu-item-radio-behavior.js';
 import 'd2l-menu/d2l-menu-item-selectable-styles.js';
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier1-icons.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-sort-by-dropdown-option">
@@ -15,10 +15,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-sort-by-dropdown-option">
 			*/
 			:host {}
 		</style>
-		<d2l-icon icon="d2l-tier1:check" aria-hidden="true"></d2l-icon>
+		<d2l-icon icon="tier1:check" aria-hidden="true"></d2l-icon>
 		<span>[[text]]</span>
 	</template>
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);

--- a/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js
+++ b/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js
@@ -1,47 +1,22 @@
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import '@brightspace-ui/core/components/icons/icon.js';
-import 'd2l-menu/d2l-menu-item-radio-behavior.js';
-import 'd2l-menu/d2l-menu-item-selectable-styles.js';
+import { html, LitElement } from 'lit-element/lit-element.js';
+import { MenuItemRadioMixin } from '@brightspace-ui/core/components/menu/menu-item-radio-mixin.js';
+import { menuItemSelectableStyles } from '@brightspace-ui/core/components/menu/menu-item-selectable-styles.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
-const $_documentContainer = document.createElement('template');
+class SortByDropdownOption extends RtlMixin(MenuItemRadioMixin(LitElement)) {
 
-$_documentContainer.innerHTML = `<dom-module id="d2l-sort-by-dropdown-option">
-	<template strip-whitespace="">
-		<style include="d2l-menu-item-selectable-styles">
-			/*
-			* https://github.com/Polymer/tools/issues/408
-			* Empty style blocks break linter.
-			*/
-			:host {}
-		</style>
-		<d2l-icon icon="tier1:check" aria-hidden="true"></d2l-icon>
-		<span>[[text]]</span>
-	</template>
-
-</dom-module>`;
-
-document.head.appendChild($_documentContainer.content);
-/**
- * `<d2l-sort-by-dropdown-option>`
- * Option for sort by dropdown
- */
-class SortByOption extends mixinBehaviors(
-	[
-		D2L.PolymerBehaviors.MenuItemRadioBehavior
-	],
-	PolymerElement
-) {
-	static get is() { return 'd2l-sort-by-dropdown-option'; }
-	static get properties() {
-		return {
-			text: {
-				type: String
-			},
-			value: {
-				type: String
-			}
-		};
+	static get styles() {
+		return menuItemSelectableStyles;
 	}
+
+	render() {
+		return html`
+			<d2l-icon icon="tier1:check" aria-hidden="true"></d2l-icon>
+			<span>${this.text}</span>
+		`;
+	}
+
 }
-customElements.define(SortByOption.is, SortByOption);
+
+customElements.define('d2l-sort-by-dropdown-option', SortByDropdownOption);

--- a/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown.js
+++ b/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown.js
@@ -1,11 +1,12 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import 'd2l-dropdown/d2l-dropdown-button-subtle.js';
-import 'd2l-dropdown/d2l-dropdown-menu.js';
-import 'd2l-menu/d2l-menu.js';
-import './d2l-sort-by-dropdown-localize-behavior.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-button-subtle.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-menu.js';
+import '@brightspace-ui/core/components/menu/menu.js';
+import './d2l-sort-by-dropdown-localize-behavior.js';
+
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-sort-by-dropdown">

--- a/demo/d2l-filter-dropdown/d2l-filter-dropdown.html
+++ b/demo/d2l-filter-dropdown/d2l-filter-dropdown.html
@@ -84,22 +84,19 @@
 								filter.totalSelectedOptionCount--;
 							}
 						});
+						/* eslint-disable no-console */
+						function logEvent(e, text) {
+							console.group(text);
+							console.log('event', e);
+							if (e.detail) console.log('detail', e.detail);
+							console.groupEnd();
+						}
+						/* eslint-enable no-console */
 					</script>
 				</template>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>
-
-		<script>
-			/* eslint-disable no-console */
-			function logEvent(e, text) {
-				console.group(text);
-				console.log('event', e);
-				if (e.detail) console.log('detail', e.detail);
-				console.groupEnd();
-			}
-			/* eslint-enable no-console */
-		</script>
 
 	</body>
 </html>

--- a/demo/d2l-filter-dropdown/d2l-filter-dropdown.html
+++ b/demo/d2l-filter-dropdown/d2l-filter-dropdown.html
@@ -3,52 +3,35 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-
-		<title>d2l-filter-dropdown demo</title>
-
-		<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
-			import '@polymer/iron-demo-helpers/demo-snippet';
-			import 'd2l-typography/d2l-typography.js';
+			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
 			import '../../components/d2l-filter-dropdown/d2l-filter-dropdown.js';
 			import '../../components/d2l-filter-dropdown/d2l-filter-dropdown-category.js';
 			import '../../components/d2l-filter-dropdown/d2l-filter-dropdown-option.js';
 			import './d2l-demo-filter.js';
-
-			const $_documentContainer = document.createElement('template');
-			$_documentContainer.innerHTML = `
-				<custom-style>
-					<style is="custom-style" include="demo-pages-shared-styles"></style>
-				</custom-style>
-				<custom-style include="d2l-typography">
-					<style is="custom-style" include="d2l-typography"></style>
-				</custom-style>
-				<style>
-					html {
-						font-size: 20px;
-					}
-					d2l-demo-filter, d2l-filter-dropdown {
-						display: inline-block;
-						margin: 0 20px;
-					}
-				</style>
-			`;
-			document.body.appendChild($_documentContainer.content);
 		</script>
+		<style>
+			d2l-demo-filter, d2l-filter-dropdown { display: inline-block; }
+		</style>
 	</head>
-	<body class="d2l-typography">
-		<div class="vertical-section-container fixedSize">
-			<h3>d2l-filter-dropdown with dom-repeat data and event hookups</h3>
-			<demo-snippet>
+	<body unresolved>
+
+		<d2l-demo-page page-title="d2l-filter-dropdown">
+
+			<h2>d2l-filter-dropdown with dom-repeat data and event hookups</h2>
+
+			<d2l-demo-snippet>
 				<template>
 					<d2l-demo-filter></d2l-demo-filter>
 				</template>
-			</demo-snippet>
-			<h3>Basic d2l-filter-dropdown with hardcoded data and events console logged</h3>
-			<demo-snippet>
-				<template strip-whitespace>
+			</d2l-demo-snippet>
+
+			<h2>Basic d2l-filter-dropdown with hardcoded data and events console logged</h2>
+
+			<d2l-demo-snippet>
+				<template>
 					<d2l-filter-dropdown id="filter" total-selected-option-count="4">
 						<d2l-filter-dropdown-category key="1" category-text="Category 1">
 							<d2l-filter-dropdown-option selected text="Option 1 - 1 test test test test test test test test test test test test test test test test test test" value="1"></d2l-filter-dropdown-option>
@@ -79,42 +62,44 @@
 							<d2l-filter-dropdown-option text="Option 5 - 3" value="3"></d2l-filter-dropdown-option>
 						</d2l-filter-dropdown-category>
 					</d2l-filter-dropdown>
+					<script>
+						var filter = document.querySelector('#filter');
+						filter.addEventListener('d2l-filter-dropdown-close', function(e) {
+							logEvent(e, 'Filter dropdown closed!');
+						});
+						filter.addEventListener('d2l-filter-dropdown-cleared', function(e) {
+							logEvent(e, 'Filters clear button clicked!');
+						});
+						filter.addEventListener('d2l-filter-dropdown-category-selected', function(e) {
+							logEvent(e, 'Filter category tab selected!');
+						});
+						filter.addEventListener('d2l-filter-dropdown-category-searched', function(e) {
+							logEvent(e, 'Filter category searched!');
+						});
+						filter.addEventListener('d2l-filter-dropdown-option-change', function(e) {
+							logEvent(e, 'Filter option clicked!');
+							if (e.detail.selected) {
+								filter.totalSelectedOptionCount++;
+							} else {
+								filter.totalSelectedOptionCount--;
+							}
+						});
+					</script>
 				</template>
-			</demo-snippet>
-		</div>
-	</body>
-	<script type="module">
-		/* eslint-disable no-console */
-		function logEvent(e, text) {
-			console.group(text);
-			console.log('event', e);
-			if (e.detail) console.log('detail', e.detail);
-			console.groupEnd();
-		}
-		/* eslint-enable no-console */
+			</d2l-demo-snippet>
 
-		window.requestAnimationFrame(function() {
-			var filter = document.querySelector('#filter');
-			filter.addEventListener('d2l-filter-dropdown-close', function(e) {
-				logEvent(e, 'Filter dropdown closed!');
-			});
-			filter.addEventListener('d2l-filter-dropdown-cleared', function(e) {
-				logEvent(e, 'Filters clear button clicked!');
-			});
-			filter.addEventListener('d2l-filter-dropdown-category-selected', function(e) {
-				logEvent(e, 'Filter category tab selected!');
-			});
-			filter.addEventListener('d2l-filter-dropdown-category-searched', function(e) {
-				logEvent(e, 'Filter category searched!');
-			});
-			filter.addEventListener('d2l-filter-dropdown-option-change', function(e) {
-				logEvent(e, 'Filter option clicked!');
-				if (e.detail.selected) {
-					filter.totalSelectedOptionCount++;
-				} else {
-					filter.totalSelectedOptionCount--;
-				}
-			});
-		});
-	</script>
+		</d2l-demo-page>
+
+		<script>
+			/* eslint-disable no-console */
+			function logEvent(e, text) {
+				console.group(text);
+				console.log('event', e);
+				if (e.detail) console.log('detail', e.detail);
+				console.groupEnd();
+			}
+			/* eslint-enable no-console */
+		</script>
+
+	</body>
 </html>

--- a/demo/d2l-search-facets/d2l-search-facets.html
+++ b/demo/d2l-search-facets/d2l-search-facets.html
@@ -3,60 +3,23 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-		<title>d2l-search-facets demo</title>
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
-		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
-		<script type="module" src="../../../d2l-typography/d2l-typography.js"></script>
-		<script type="module" src="../../components/d2l-search-facets/d2l-search-facets.js"></script>
-		<script type="module" src="../../components/d2l-search-facets/d2l-search-facets-grouping.js"></script>
-		<script type="module" src="../../components/d2l-search-facets/d2l-search-facets-option.js"></script>
-		<script type="module" src="./d2l-search-facets-demo-components.js"></script>
-		<!-- FIXME(polymer-modulizer):
-		These imperative modules that innerHTML your HTML are
-		a hacky way to be sure that any mixins in included style
-		modules are ready before any elements that reference them are
-		instantiated, otherwise the CSS @apply mixin polyfill won't be
-		able to expand the underlying CSS custom properties.
-		See: https://github.com/Polymer/polymer-modulizer/issues/154
-		-->
-	<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<custom-style>
-			<style is="custom-style" include="demo-pages-shared-styles"></style>
-		</custom-style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<custom-style include="d2l-typography">
-			<style is="custom-style" include="d2l-typography"></style>
-		</custom-style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
-		<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<style>
-			html {
-				font-size: 20px;
-			}
-		</style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
+			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+			import '../../components/d2l-search-facets/d2l-search-facets.js';
+			import '../../components/d2l-search-facets/d2l-search-facets-grouping.js';
+			import '../../components/d2l-search-facets/d2l-search-facets-option.js';
+			import './d2l-search-facets-demo-components.js';
+		</script>
 	</head>
-	<body unresolved class="d2l-typography">
-		<script type="module">
-const $_documentContainer = document.createElement('template');
+	<body unresolved>
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container centered">
-			<h3>d2l-search-facets</h3>
-			<demo-snippet>
+		<d2l-demo-page page-title="d2l-search-facets">
+
+			<h2>d2l-search-facets</h2>
+
+			<d2l-demo-snippet>
 				<template>
 					<d2l-search-facets>
 						<d2l-search-facets-grouping id="status" value="status" text="My Status" has-more="">
@@ -72,69 +35,52 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 							<d2l-search-facets-option value="inside" text="Inside"></d2l-search-facets-option>
 						</d2l-search-facets-grouping>
 					</d2l-search-facets>
+					<script>
+						document.getElementById('status').addEventListener('d2l-search-facets-grouping-has-more', function(e) {
+							const options = [
+								{ text: 'In Progress', value: 'in-progress', count: '1' },
+								{ text: 'Completed', value: 'completed', count: '10000' }
+							];
+							addOptions(options, e.target);
+						});
+						document.getElementById('format').addEventListener('d2l-search-facets-grouping-has-more', function(e) {
+							const options = [
+								{ text: 'Interactive', value: 'interactive', count: '12' },
+								{ text: 'Video Only', value: 'video-only', count: '30' }
+							];
+							addOptions(options, e.target);
+						});
+					</script>
 				</template>
-			</demo-snippet>
-		</div>`;
+			</d2l-demo-snippet>
 
-document.body.appendChild($_documentContainer.content);
-</script>
-		<script type="module">
-const $_documentContainer = document.createElement('template');
+			<h2>d2l-search-facets (templated)</h2>
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container centered">
-			<h3>Templated d2l-search-facets demo</h3>
-			<demo-snippet>
+			<d2l-demo-snippet>
 				<template>
 					<d2l-demo-templated-search-facets></d2l-demo-templated-search-facets>
 				</template>
-			</demo-snippet>
-		</div>`;
+			</d2l-demo-snippet>
 
-document.body.appendChild($_documentContainer.content);
-</script>
+		</d2l-demo-page>
+
+		<script>
+			document.addEventListener('d2l-search-facets-change', function(e) {
+				// eslint-disable-next-line no-console
+				console.log(e.detail);
+			});
+
+			function addOptions(options, target) {
+				options.forEach(function(option) {
+					const element = document.createElement('d2l-search-facets-option');
+					element.setAttribute('text', option.text);
+					element.setAttribute('value', option.value);
+					element.setAttribute('count', option.count);
+					target.appendChild(element);
+				});
+				target.removeAttribute('has-more');
+			}
+		</script>
+
 	</body>
-	<script type="module">
-import '@polymer/iron-demo-helpers/demo-pages-shared-styles.js';
-import '@polymer/iron-demo-helpers/demo-snippet.js';
-import 'd2l-typography/d2l-typography.js';
-import '../../components/d2l-search-facets/d2l-search-facets.js';
-import '../../components/d2l-search-facets/d2l-search-facets-grouping.js';
-import '../../components/d2l-search-facets/d2l-search-facets-option.js';
-import './d2l-search-facets-demo-components.js';
-requestAnimationFrame(function() {
-	document.body.classList.add('d2l-typography');
-
-	document.addEventListener('d2l-search-facets-change', function(e) {
-		// eslint-disable-next-line no-console
-		console.log(e.detail);
-	});
-
-	document.getElementById('status').addEventListener('d2l-search-facets-grouping-has-more', function(e) {
-		const options = [
-			{ text: 'In Progress', value: 'in-progress', count: '1' },
-			{ text: 'Completed', value: 'completed', count: '10000' }
-		];
-		addOptions(options, e.target);
-	});
-
-	document.getElementById('format').addEventListener('d2l-search-facets-grouping-has-more', function(e) {
-		const options = [
-			{ text: 'Interactive', value: 'interactive', count: '12' },
-			{ text: 'Video Only', value: 'video-only', count: '30' }
-		];
-		addOptions(options, e.target);
-	});
-});
-
-function addOptions(options, target) {
-	options.forEach(function(option) {
-		const element = document.createElement('d2l-search-facets-option');
-		element.setAttribute('text', option.text);
-		element.setAttribute('value', option.value);
-		element.setAttribute('count', option.count);
-		target.appendChild(element);
-	});
-	target.removeAttribute('has-more');
-}
-</script>
 </html>

--- a/demo/d2l-search-facets/d2l-search-facets.html
+++ b/demo/d2l-search-facets/d2l-search-facets.html
@@ -50,6 +50,16 @@
 							];
 							addOptions(options, e.target);
 						});
+						function addOptions(options, target) {
+							options.forEach(function(option) {
+								const element = document.createElement('d2l-search-facets-option');
+								element.setAttribute('text', option.text);
+								element.setAttribute('value', option.value);
+								element.setAttribute('count', option.count);
+								target.appendChild(element);
+							});
+							target.removeAttribute('has-more');
+						}
 					</script>
 				</template>
 			</d2l-demo-snippet>
@@ -69,17 +79,6 @@
 				// eslint-disable-next-line no-console
 				console.log(e.detail);
 			});
-
-			function addOptions(options, target) {
-				options.forEach(function(option) {
-					const element = document.createElement('d2l-search-facets-option');
-					element.setAttribute('text', option.text);
-					element.setAttribute('value', option.value);
-					element.setAttribute('count', option.count);
-					target.appendChild(element);
-				});
-				target.removeAttribute('has-more');
-			}
 		</script>
 
 	</body>

--- a/demo/d2l-search-results-count/d2l-search-results-count.html
+++ b/demo/d2l-search-results-count/d2l-search-results-count.html
@@ -3,119 +3,54 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-		<title>d2l-search-results-count demo</title>
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
-		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
-		<script type="module" src="../../../d2l-typography/d2l-typography.js"></script>
-		<script type="module" src="../../components/d2l-search-results-count/d2l-search-results-count.js"></script>
-		<!-- FIXME(polymer-modulizer):
-		These imperative modules that innerHTML your HTML are
-		a hacky way to be sure that any mixins in included style
-		modules are ready before any elements that reference them are
-		instantiated, otherwise the CSS @apply mixin polyfill won't be
-		able to expand the underlying CSS custom properties.
-		See: https://github.com/Polymer/polymer-modulizer/issues/154
-		-->
-	<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<custom-style>
-			<style is="custom-style" include="demo-pages-shared-styles"></style>
-		</custom-style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<custom-style include="d2l-typography">
-			<style is="custom-style" include="d2l-typography"></style>
-		</custom-style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
-		<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<style>
-			html {
-				font-size: 20px;
-			}
-		</style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
+			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+			import '../../components/d2l-search-results-count/d2l-search-results-count.js';
+		</script>
 	</head>
-	<body unresolved class="d2l-typography">
-		<script type="module">
-const $_documentContainer = document.createElement('template');
+	<body unresolved>
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container centered">
-				<h3>d2l-search-results-count</h3>
-				<demo-snippet>
-					<template>
-						<d2l-search-results-count total-count="22" query="Financial Planning">
-						</d2l-search-results-count>
-					</template>
-				</demo-snippet>
-			</div>`;
+		<d2l-demo-page page-title="d2l-search-results-count">
 
-document.body.appendChild($_documentContainer.content);
-</script>
-			<script type="module">
-const $_documentContainer = document.createElement('template');
+			<h2>d2l-search-results-count</h2>
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container centered">
-				<h3>d2l-search-results-count no query</h3>
-				<demo-snippet>
-					<template>
-						<d2l-search-results-count total-count="22">
-						</d2l-search-results-count>
-					</template>
-				</demo-snippet>
-			</div>`;
+			<d2l-demo-snippet>
+				<template>
+					<d2l-search-results-count total-count="22" query="Financial Planning">
+					</d2l-search-results-count>
+				</template>
+			</d2l-demo-snippet>
 
-document.body.appendChild($_documentContainer.content);
-</script>
-		<script type="module">
-const $_documentContainer = document.createElement('template');
+			<h2>d2l-search-results-count (no query)</h2>
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container centered">
-			<h3>d2l-search-results-count paged</h3>
-			<demo-snippet>
+			<d2l-demo-snippet>
+				<template>
+					<d2l-search-results-count total-count="22">
+					</d2l-search-results-count>
+				</template>
+			</d2l-demo-snippet>
+
+			<h2>d2l-search-results-count (paged)</h2>
+
+			<d2l-demo-snippet>
 				<template>
 					<d2l-search-results-count range-start="1" range-end="20" total-count="22" query="Financial Planning">
 					</d2l-search-results-count>
 				</template>
-			</demo-snippet>
-		</div>`;
+			</d2l-demo-snippet>
 
-document.body.appendChild($_documentContainer.content);
-</script>
-		<script type="module">
-const $_documentContainer = document.createElement('template');
+			<h2>d2l-search-results-count (paged, no query)</h2>
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container centered">
-			<h3>d2l-search-results-count paged no query</h3>
-			<demo-snippet>
+			<d2l-demo-snippet>
 				<template>
 					<d2l-search-results-count range-start="1" range-end="20" total-count="22">
 					</d2l-search-results-count>
 				</template>
-			</demo-snippet>
-		</div>`;
+			</d2l-demo-snippet>
 
-document.body.appendChild($_documentContainer.content);
-</script>
+		</d2l-demo-page>
+
 	</body>
-	<script type="module">
-import '@polymer/iron-demo-helpers/demo-pages-shared-styles.js';
-import '@polymer/iron-demo-helpers/demo-snippet.js';
-import 'd2l-typography/d2l-typography.js';
-import '../../components/d2l-search-results-count/d2l-search-results-count.js';
-requestAnimationFrame(function() {
-	document.body.classList.add('d2l-typography');
-});
-</script>
 </html>

--- a/demo/d2l-sort-by-dropdown/d2l-sort-by-dropdown.html
+++ b/demo/d2l-sort-by-dropdown/d2l-sort-by-dropdown.html
@@ -3,65 +3,24 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-		<title>d2l-sort-by-dropdown demo</title>
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
-		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
-		<script type="module" src="../../../d2l-typography/d2l-typography.js"></script>
-		<script type="module" src="../../components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js"></script>
-		<script type="module" src="../../components/d2l-sort-by-dropdown/d2l-sort-by-dropdown.js"></script>
-		<!-- FIXME(polymer-modulizer):
-		These imperative modules that innerHTML your HTML are
-		a hacky way to be sure that any mixins in included style
-		modules are ready before any elements that reference them are
-		instantiated, otherwise the CSS @apply mixin polyfill won't be
-		able to expand the underlying CSS custom properties.
-		See: https://github.com/Polymer/polymer-modulizer/issues/154
-		-->
-	<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<custom-style>
-			<style is="custom-style" include="demo-pages-shared-styles"></style>
-		</custom-style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<custom-style include="d2l-typography">
-			<style is="custom-style" include="d2l-typography"></style>
-		</custom-style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
-		<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<style>
-			html {
-				font-size: 20px;
-			}
-			demo-snippet {
-				display: flex !important; /* IE11 */
-				flex-direction: column;
-			}
-			d2l-sort-by-dropdown {
-				float: right;
-			}
-		</style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
+			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+			import '../../components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js';
+			import '../../components/d2l-sort-by-dropdown/d2l-sort-by-dropdown.js';
+		</script>
+		<style>
+			d2l-sort-by-dropdown { float: right; }
+		</style>
 	</head>
-	<body unresolved class="d2l-typography">
-		<script type="module">
-const $_documentContainer = document.createElement('template');
+	<body unresolved>
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container centered">
-			<h3>d2l-sort-by-dropdown</h3>
-			<demo-snippet>
+		<d2l-demo-page page-title="d2l-sort-by-dropdown">
+
+			<h2>d2l-sort-by-dropdown</h2>
+
+			<d2l-demo-snippet>
 				<template>
 					<d2l-sort-by-dropdown label="Sort by options" align="end">
 						<d2l-sort-by-dropdown-option value="date" text="Date"></d2l-sort-by-dropdown-option>
@@ -73,35 +32,30 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 						<d2l-sort-by-dropdown-option value="low-to-high" text="Price: Low to High"></d2l-sort-by-dropdown-option>
 						<d2l-sort-by-dropdown-option value="long-text" text="A sorting option with longer text"></d2l-sort-by-dropdown-option>
 					</d2l-sort-by-dropdown>
+					<div style="clear: both;"></div>
 				</template>
-			</demo-snippet>
-			<h3>d2l-sort-by-dropdown (compact)</h3>
-			<demo-snippet>
+			</d2l-demo-snippet>
+
+			<h2>d2l-sort-by-dropdown (compact)</h2>
+
+			<d2l-demo-snippet>
 				<template>
 					<d2l-sort-by-dropdown align="end" label="Compact sort by dropdown" compact="">
 						<d2l-sort-by-dropdown-option value="date" text="Date"></d2l-sort-by-dropdown-option>
 						<d2l-sort-by-dropdown-option value="time" text="Time"></d2l-sort-by-dropdown-option>
 					</d2l-sort-by-dropdown>
+					<div style="clear: both;"></div>
 				</template>
-			</demo-snippet>
-		</div>`;
+			</d2l-demo-snippet>
 
-document.body.appendChild($_documentContainer.content);
-</script>
+		</d2l-demo-page>
+
+		<script>
+			document.addEventListener('d2l-sort-by-dropdown-change', function(e) {
+				// eslint-disable-next-line no-console
+				console.log(e.detail);
+			});
+		</script>
+
 	</body>
-	<script type="module">
-import '@polymer/iron-demo-helpers/demo-pages-shared-styles.js';
-import '@polymer/iron-demo-helpers/demo-snippet.js';
-import 'd2l-typography/d2l-typography.js';
-import '../../components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js';
-import '../../components/d2l-sort-by-dropdown/d2l-sort-by-dropdown.js';
-requestAnimationFrame(function() {
-	document.body.classList.add('d2l-typography');
-});
-
-document.addEventListener('d2l-sort-by-dropdown-change', function(e) {
-	// eslint-disable-next-line no-console
-	console.log(e.detail);
-});
-</script>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,64 +3,24 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-		<title>d2l-facet-filter-search demos</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
-		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
-		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>
-		<!-- FIXME(polymer-modulizer):
-		These imperative modules that innerHTML your HTML are
-		a hacky way to be sure that any mixins in included style
-		modules are ready before any elements that reference them are
-		instantiated, otherwise the CSS @apply mixin polyfill won't be
-		able to expand the underlying CSS custom properties.
-		See: https://github.com/Polymer/polymer-modulizer/issues/154
-		-->
-	<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<custom-style>
-			<style is="custom-style" include="demo-pages-shared-styles"></style>
-		</custom-style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<custom-style include="d2l-typography">
-			<style is="custom-style" include="d2l-typography"></style>
-		</custom-style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
-		<script type="module">
-const $_documentContainer = document.createElement('template');
-
-$_documentContainer.innerHTML = `<style>
-			html {
-				font-size: 20px;
-			}
-		</style>`;
-
-document.body.appendChild($_documentContainer.content);
-</script>
+			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+		</script>
 	</head>
 	<body class="d2l-typography">
-		<script type="module">
-const $_documentContainer = document.createElement('template');
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container fixedSize">
-			<h3>Demos</h3>
+		<d2l-demo-page page-title="demos">
+
 			<ul>
 				<li><a href="d2l-filter-dropdown/d2l-filter-dropdown.html">d2l-filter-dropdown</a></li>
 				<li><a href="d2l-search-facets/d2l-search-facets.html">d2l-search-facets</a></li>
 				<li><a href="d2l-search-results-count/d2l-search-results-count.html">d2l-search-results-count</a></li>
 				<li><a href="d2l-sort-by-dropdown/d2l-sort-by-dropdown.html">d2l-sort-by-dropdown</a></li>
 			</ul>
-		</div>`;
 
-document.body.appendChild($_documentContainer.content);
-</script>
+		</d2l-demo-page>
+
 	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@webcomponents/webcomponentsjs": "^2.2.4",
     "babel-eslint": "^10.0.1",
     "chromedriver": "^2.40.0",
-    "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "eslint": "^4.19.1",
     "eslint-config-brightspace": "^0.4.0",
     "eslint-plugin-html": "^4.0.5",
@@ -38,15 +37,12 @@
     "type-detect": "1.0.0"
   },
   "dependencies": {
-    "d2l-button": "BrightspaceUI/button#semver:^5",
-    "d2l-colors": "BrightspaceUI/colors#semver:^4",
-    "d2l-dropdown": "BrightspaceUI/dropdown#semver:^7",
-    "d2l-icons": "BrightspaceUI/icons#semver:^6",
-    "d2l-inputs": "BrightspaceUI/inputs#semver:^2",
+    "@brightspace-ui/core": "^1.43.3",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-menu": "BrightspaceUI/menu#semver:^2",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
     "d2l-tabs": "BrightspaceUI/tabs#semver:^1",
+    "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "@polymer/polymer": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@polymer/iron-demo-helpers": "^3.0.0",
-    "@polymer/iron-test-helpers": "^3.0.0",
     "@webcomponents/webcomponentsjs": "^2.2.4",
     "babel-eslint": "^10.0.1",
     "chromedriver": "^2.40.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@polymer/iron-test-helpers": "^3.0.0",
     "@webcomponents/webcomponentsjs": "^2.2.4",
     "babel-eslint": "^10.0.1",
     "chromedriver": "^2.40.0",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
   "dependencies": {
     "@brightspace-ui/core": "^1.43.3",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
-    "d2l-menu": "BrightspaceUI/menu#semver:^2",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
     "d2l-tabs": "BrightspaceUI/tabs#semver:^1",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
+    "lit-element": "^2",
     "@polymer/polymer": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@brightspace-ui/core": "^1.43.3",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-    "d2l-tabs": "BrightspaceUI/tabs#semver:^1",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "lit-element": "^2",
     "@polymer/polymer": "^3.0.0"

--- a/test/d2l-filter-dropdown/d2l-filter-dropdown-category.html
+++ b/test/d2l-filter-dropdown/d2l-filter-dropdown-category.html
@@ -8,7 +8,7 @@
 
 		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../../wct-browser-legacy/browser.js"></script>
-		<script type="module" src="../../../d2l-tabs/d2l-tabs.js"></script>
+		<script type="module" src="../../../@brightspace-ui/core/components/tabs/tabs.js"></script>
 		<script type="module" src="../../components/d2l-filter-dropdown/d2l-filter-dropdown-category.js"></script>
 		<script type="module" src="../../components/d2l-filter-dropdown/d2l-filter-dropdown-option.js"></script>
 	</head>
@@ -74,22 +74,24 @@
 					searchInput = categories[1].shadowRoot.querySelector('.d2l-filter-dropdown-page-search');
 					assert.equal(searchInput.hidden, true);
 				});
-				test('setting the search-value attribute updates the value in the search input', function() {
+				test('setting the search-value attribute updates the value in the search input', function(done) {
 					categories[0].searchValue = 'test';
-
-					var searchInput = categories[0].shadowRoot.querySelector('d2l-input-search');
-					assert.equal(searchInput.value, 'test');
+					categories[0].updateComplete.then(function() {
+						var searchInput = categories[0].shadowRoot.querySelector('d2l-input-search');
+						assert.equal(searchInput.value, 'test');
+						done();
+					});
 				});
 				test('searching triggers the d2l-filter-dropdown-category-searched event', function(done) {
-					categories[0].searchValue = 'test';
-
 					container.addEventListener('d2l-filter-dropdown-category-searched', function(e) {
 						assert.equal(e.detail.categoryKey, '1');
 						assert.equal(e.detail.value, 'test');
 						done();
 					});
-
-					categories[0].shadowRoot.querySelector('d2l-input-search').search();
+					categories[0].searchValue = 'test';
+					categories[0].updateComplete.then(function() {
+						categories[0].shadowRoot.querySelector('d2l-input-search').search();
+					});
 				});
 				test('changing the category tab triggers the d2l-filter-dropdown-category-selected event', function(done) {
 					container.addEventListener('d2l-filter-dropdown-category-selected', function(e) {

--- a/test/d2l-filter-dropdown/d2l-filter-dropdown-option.html
+++ b/test/d2l-filter-dropdown/d2l-filter-dropdown-option.html
@@ -9,7 +9,7 @@
 		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../../wct-browser-legacy/browser.js"></script>
 		<script src="../../../@polymer/iron-test-helpers/mock-interactions.js" type="module"></script>
-		<script type="module" src="../../../d2l-menu/d2l-menu.js"></script>
+		<script type="module" src="../../../@brightspace-ui/core/components/menu/menu.js"></script>
 		<script type="module" src="../../components/d2l-filter-dropdown/d2l-filter-dropdown-option.js"></script>
 	</head>
 	<body>
@@ -73,13 +73,16 @@
 						assert.equal(options[0].selected, expected);
 						assert.equal(e.detail.selected, expected);
 						assert.equal(e.detail.value, '1');
-						assert.equal(window.getComputedStyle(options[0].shadowRoot.querySelector('d2l-icon')).getPropertyValue('visibility'), expected ? 'visible' : 'hidden');
-						if (!expected) {
-							done();
-						}
-						expected = false;
+						options[0].updateComplete.then(function() {
+							assert.equal(window.getComputedStyle(options[0].shadowRoot.querySelector('d2l-icon')).getPropertyValue('visibility'), expected ? 'visible' : 'hidden');
+							if (expected) {
+								expected = false;
+								options[0].click();
+							} else {
+								done();
+							}
+						});
 					});
-					options[0].click();
 					options[0].click();
 				});
 				test('does not affect other checkboxes in the menu when selected', function(done) {

--- a/test/d2l-filter-dropdown/d2l-filter-dropdown.html
+++ b/test/d2l-filter-dropdown/d2l-filter-dropdown.html
@@ -118,7 +118,7 @@
 				});
 				test('filter categories display correctly', function(done) {
 					function getTabs() {
-						var tabs = filter.shadowRoot.querySelector('d2l-tabs').shadowRoot.querySelectorAll('d2l-tab');
+						var tabs = filter.shadowRoot.querySelector('d2l-tabs').shadowRoot.querySelectorAll('d2l-tab-internal');
 						if (tabs.length === 2) {
 							assert.equal(tabs[0].text, 'Category 1 (3)');
 							assert.equal(tabs[1].text, 'Category 2');


### PR DESCRIPTION
This PR probably looks scarier than it should.  It's basically house-keeping and couple conversions to Lit in order to remove dependency on Polymer behaviors.

* replace `d2l-filter-dropdown-category` custom Polymer tab panel with Lit version
* replace `d2l-filter-dropdown-option` custom Polymer menu item with Lit version
* replace `d2l-sort-by-dropdown-option` custom Polymer menu item with Lit version
* update all imports to pull from `core` except for typography where mixin is being used
* cleanup all demo pages so they are easier to work with and don't use iron demo snippet
* fix a few tests that broke as a result of Lit rendering being async