### PR TITLE
Add custom-elements.json

### DIFF
--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -11,9 +11,15 @@ const DROPDOWN_NAME = 'D2L-FILTER-DROPDOWN';
 const DROPDOWN_CATEGORY_NAME = 'D2L-FILTER-DROPDOWN-CATEGORY';
 const DROPDOWN_OPTION_NAME = 'D2L-FILTER-DROPDOWN-OPTION';
 
+/**
+ * A multi-select-list allowing the user to see (and remove) the currently applied filters.
+ */
 class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 	static get properties() {
 		return {
+			/**
+			 * REQUIRED: The id of the "d2l-filter-dropdown" that you want to track
+			 */
 			for: { type: String },
 			_entries: { type: Array },
 			_selectedEntries: { type: Array },

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
@@ -6,14 +6,37 @@ import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeStaticMixin } from '@brightspace-ui/core/mixins/localize-static-mixin.js';
 import { TabPanelMixin } from '@brightspace-ui/core/components/tabs/tab-panel-mixin.js';
 
+/**
+ * A component wrapping grouped filters
+ * @slot - Contains the filters (e.g., d2l-filter-dropdown-option) that are in the category
+ * @fires d2l-filter-dropdown-category-slotchange - Dispatched when the slot content changes
+ * @fires d2l-filter-dropdown-category-selected - Dispatched when a filter tab is selected
+ * @fires d2l-filter-dropdown-category-searched - Dispatched when a filter category is searched
+ * @fires d2l-filter-dropdown-option-change - Dispatched when a filter option is selected
+ */
 class FilterDropdownCategory extends LocalizeStaticMixin(TabPanelMixin(LitElement)) {
 
 	static get properties() {
 		return {
+			/**
+			 * REQUIRED: Name of the filter category, will be shown on the tab
+			 */
 			categoryText: { type: String, attribute: 'category-text' },
+			/**
+			 * Hides the search bar inside a filter tab
+			 */
 			disableSearch: { type: Boolean, attribute: 'disable-search' },
+			/**
+			 * Unique id to represent a filter category, sent back in category events
+			 */
 			key: { type: String },
+			/**
+			 * Sets the value in the search input, useful if setting up the filter in a default state
+			 */
 			searchValue: { type: String, attribute: 'search-value' },
+			/**
+			 * The number of selected filter options for that filter category.  When options are selected and de-selected, the consumer is responsible for updating this number after updating its own data store.
+			 */
 			selectedOptionCount: { type: Number, attribute: 'selected-option-count' }
 		};
 	}

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js
@@ -4,6 +4,9 @@ import { MenuItemSelectableMixin } from '@brightspace-ui/core/components/menu/me
 import { menuItemSelectableStyles } from '@brightspace-ui/core/components/menu/menu-item-selectable-styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
+/**
+ * A filter menu item component.
+ */
 class FilterDropdownOption extends RtlMixin(MenuItemSelectableMixin(LitElement)) {
 
 	static get styles() {

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown.js
@@ -8,10 +8,12 @@ import '@brightspace-ui/core/components/tabs/tabs.js';
 import './d2l-filter-dropdown-localize-behavior.js';
 
 /**
- * @customElement
- * @polymer
+ * A component containing filter options and emitting selection events
+ * @slot - Contents of the dropdown, including filter categories and options
+ * @slot footer - Dropdown footer contents
+ * @fires d2l-filter-dropdown-cleared - Dispatched when the clear button is pressed to clear all filters
+ * @fires d2l-filter-dropdown-close - Dispatched when the filter dropdown is closed
  */
-
 class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropdown.LocalizeBehavior], PolymerElement) {
 	static get template() {
 		return html`
@@ -57,41 +59,68 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 	static get is() { return 'd2l-filter-dropdown'; }
 	static get properties() {
 		return {
-			minWidth: {
-				type: Number,
-				value: 25
+			/**
+			 * Disables the dropdown opener
+			 */
+			disabled: {
+				type: Boolean,
+				value: false
 			},
-			maxWidth: {
-				type: Number,
-				value: 400
-			},
-			totalSelectedOptionCount: {
-				type: Number,
-				value: 0
-			},
-			headerText: {
-				type: String,
-				value: ''
-			},
-			openerText: {
-				type: String,
-				value: ''
-			},
-			openerTextSingle: {
-				type: String,
-				value: ''
-			},
-			openerTextMultiple: {
-				type: String,
-				value: ''
-			},
+			/**
+			 * Disables displaying different text for different number of selections, instead always displaying the term for no selections.
+			 */
 			disableOpenerTextVariation: {
 				type: Boolean,
 				value: false
 			},
-			disabled: {
-				type: Boolean,
-				value: false
+			/**
+			 * Sets the text for the filter content header
+			 */
+			headerText: {
+				type: String,
+				value: ''
+			},
+			/**
+			 * Sets the max-width of the filter dropdown
+			 */
+			maxWidth: {
+				type: Number,
+				value: 400
+			},
+			/**
+			 * Sets the min-width of the filter dropdown
+			 */
+			minWidth: {
+				type: Number,
+				value: 25
+			},
+			/**
+			 * Sets the text for the opener when there are no selections
+			 */
+			openerText: {
+				type: String,
+				value: ''
+			},
+			/**
+			 * Sets the text for the opener when there are multiple selections
+			 */
+			openerTextMultiple: {
+				type: String,
+				value: ''
+			},
+			/**
+			 * Sets the text for the opener when there is a single selection
+			 */
+			openerTextSingle: {
+				type: String,
+				value: ''
+			},
+			/**
+			 * The total number of selected filter options across all categories.  When options are selected and de-selected, the consumer is responsible for updating this number after updating its own data store.
+			 */
+			totalSelectedOptionCount: {
+				type: Number,
+				value: 0
 			},
 			_hasFooter: {
 				type: Boolean,

--- a/components/d2l-search-facets/d2l-search-facets-grouping.js
+++ b/components/d2l-search-facets/d2l-search-facets-grouping.js
@@ -59,8 +59,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-search-facets-grouping">
 
 document.head.appendChild($_documentContainer.content);
 /**
- * `<d2l-search-facets-grouping>`
  * A grouping of search facet options that keeps tracks of selected options
+ * @slot - Contains the search facets in the group
+ * @fires d2l-search-facets-grouping-change - Dispatched when the search group changes
+ * @fires d2l-search-facets-grouping-has-more - Dispatched when the more button is clicked
  */
 class SearchFacetsGrouping extends mixinBehaviors(
 	[

--- a/components/d2l-search-facets/d2l-search-facets-option.js
+++ b/components/d2l-search-facets/d2l-search-facets-option.js
@@ -19,8 +19,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-search-facets-option">
 
 document.head.appendChild($_documentContainer.content);
 /**
- * `<d2l-search-facets-option>`
  * Search facet option, with a count to display the number of results
+ * @fires d2l-search-facets-option-change - Dispatched when the checked value of an option changes
  */
 class SearchFacetsOption extends mixinBehaviors(
 	[

--- a/components/d2l-search-facets/d2l-search-facets.js
+++ b/components/d2l-search-facets/d2l-search-facets.js
@@ -17,8 +17,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-search-facets">
 
 document.head.appendChild($_documentContainer.content);
 /**
- * `<d2l-search-facets>`
  * Polymer-based web component for D2L search facets.
+ * @fires d2l-search-facets-change - Dispatched when the search facets group changes
  */
 class SearchFacets extends PolymerElement {
 	static get is() { return 'd2l-search-facets'; }

--- a/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js
+++ b/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js
@@ -4,6 +4,9 @@ import { MenuItemRadioMixin } from '@brightspace-ui/core/components/menu/menu-it
 import { menuItemSelectableStyles } from '@brightspace-ui/core/components/menu/menu-item-selectable-styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
+/**
+ * A dropdown option menu item component.
+ */
 class SortByDropdownOption extends RtlMixin(MenuItemRadioMixin(LitElement)) {
 
 	static get styles() {

--- a/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown.js
+++ b/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown.js
@@ -32,8 +32,9 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-sort-by-dropdown">
 
 document.head.appendChild($_documentContainer.content);
 /**
- * `<d2l-sort-by-dropdown>`
  * Polymer-based web component for D2L sort by dropdown component
+ * @slot - Contains the dropdown options (e.g., d2l-sort-by-dropdown-options)
+ * @fires d2l-sort-by-dropdown-change - Dispatched when option is selected
  */
 class SortByDropdown extends mixinBehaviors(
 	[

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -1,0 +1,708 @@
+{
+  "version": "experimental",
+  "tags": [
+    {
+      "name": "d2l-applied-filters",
+      "path": "./components/d2l-applied-filters/d2l-applied-filters.js",
+      "description": "A multi-select-list allowing the user to see (and remove) the currently applied filters.",
+      "attributes": [
+        {
+          "name": "for",
+          "description": "REQUIRED: The id of the \"d2l-filter-dropdown\" that you want to track",
+          "type": "string"
+        }
+      ],
+      "properties": [
+        {
+          "name": "for",
+          "attribute": "for",
+          "description": "REQUIRED: The id of the \"d2l-filter-dropdown\" that you want to track",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "name": "d2l-filter-dropdown-category",
+      "path": "./components/d2l-filter-dropdown/d2l-filter-dropdown-category.js",
+      "description": "A component wrapping grouped filters",
+      "attributes": [
+        {
+          "name": "search-value",
+          "description": "Sets the value in the search input, useful if setting up the filter in a default state",
+          "type": "string"
+        },
+        {
+          "name": "category-text",
+          "description": "REQUIRED: Name of the filter category, will be shown on the tab",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "disable-search",
+          "description": "Hides the search bar inside a filter tab",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "key",
+          "description": "Unique id to represent a filter category, sent back in category events",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "selected-option-count",
+          "description": "The number of selected filter options for that filter category.  When options are selected and de-selected, the consumer is responsible for updating this number after updating its own data store.",
+          "type": "number",
+          "default": "0"
+        }
+      ],
+      "properties": [
+        {
+          "name": "searchValue",
+          "attribute": "search-value",
+          "description": "Sets the value in the search input, useful if setting up the filter in a default state",
+          "type": "string"
+        },
+        {
+          "name": "categoryText",
+          "attribute": "category-text",
+          "description": "REQUIRED: Name of the filter category, will be shown on the tab",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "disableSearch",
+          "attribute": "disable-search",
+          "description": "Hides the search bar inside a filter tab",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "key",
+          "attribute": "key",
+          "description": "Unique id to represent a filter category, sent back in category events",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "selectedOptionCount",
+          "attribute": "selected-option-count",
+          "description": "The number of selected filter options for that filter category.  When options are selected and de-selected, the consumer is responsible for updating this number after updating its own data store.",
+          "type": "number",
+          "default": "0"
+        }
+      ],
+      "events": [
+        {
+          "name": "d2l-filter-dropdown-category-slotchange",
+          "description": "Dispatched when the slot content changes"
+        },
+        {
+          "name": "d2l-filter-dropdown-category-selected",
+          "description": "Dispatched when a filter tab is selected"
+        },
+        {
+          "name": "d2l-filter-dropdown-category-searched",
+          "description": "Dispatched when a filter category is searched"
+        },
+        {
+          "name": "d2l-filter-dropdown-option-change",
+          "description": "Dispatched when a filter option is selected"
+        }
+      ],
+      "slots": [
+        {
+          "name": "",
+          "description": "Contains the filters (e.g., d2l-filter-dropdown-option) that are in the category"
+        }
+      ]
+    },
+    {
+      "name": "d2l-filter-dropdown-option",
+      "path": "./components/d2l-filter-dropdown/d2l-filter-dropdown-option.js",
+      "description": "A filter menu item component.",
+      "properties": [
+        {
+          "name": "role",
+          "type": "string",
+          "default": "\"menuitemcheckbox\""
+        }
+      ],
+      "events": [
+        {
+          "name": "d2l-menu-item-select"
+        }
+      ]
+    },
+    {
+      "name": "d2l-filter-dropdown",
+      "path": "./components/d2l-filter-dropdown/d2l-filter-dropdown.js",
+      "description": "A component containing filter options and emitting selection events",
+      "attributes": [
+        {
+          "name": "disabled",
+          "description": "Disables the dropdown opener",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "disable-opener-text-variation",
+          "description": "Disables displaying different text for different number of selections, instead always displaying the term for no selections.",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "header-text",
+          "description": "Sets the text for the filter content header",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "max-width",
+          "description": "Sets the max-width of the filter dropdown",
+          "type": "number",
+          "default": "400"
+        },
+        {
+          "name": "min-width",
+          "description": "Sets the min-width of the filter dropdown",
+          "type": "number",
+          "default": "25"
+        },
+        {
+          "name": "opener-text",
+          "description": "Sets the text for the opener when there are no selections",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "opener-text-multiple",
+          "description": "Sets the text for the opener when there are multiple selections",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "opener-text-single",
+          "description": "Sets the text for the opener when there is a single selection",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "total-selected-option-count",
+          "description": "The total number of selected filter options across all categories.  When options are selected and de-selected, the consumer is responsible for updating this number after updating its own data store.",
+          "type": "number",
+          "default": "0"
+        },
+        {
+          "name": "no-padding-footer",
+          "type": "boolean",
+          "default": "false"
+        }
+      ],
+      "properties": [
+        {
+          "name": "disabled",
+          "attribute": "disabled",
+          "description": "Disables the dropdown opener",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "disableOpenerTextVariation",
+          "attribute": "disable-opener-text-variation",
+          "description": "Disables displaying different text for different number of selections, instead always displaying the term for no selections.",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "headerText",
+          "attribute": "header-text",
+          "description": "Sets the text for the filter content header",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "maxWidth",
+          "attribute": "max-width",
+          "description": "Sets the max-width of the filter dropdown",
+          "type": "number",
+          "default": "400"
+        },
+        {
+          "name": "minWidth",
+          "attribute": "min-width",
+          "description": "Sets the min-width of the filter dropdown",
+          "type": "number",
+          "default": "25"
+        },
+        {
+          "name": "openerText",
+          "attribute": "opener-text",
+          "description": "Sets the text for the opener when there are no selections",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "openerTextMultiple",
+          "attribute": "opener-text-multiple",
+          "description": "Sets the text for the opener when there are multiple selections",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "openerTextSingle",
+          "attribute": "opener-text-single",
+          "description": "Sets the text for the opener when there is a single selection",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "totalSelectedOptionCount",
+          "attribute": "total-selected-option-count",
+          "description": "The total number of selected filter options across all categories.  When options are selected and de-selected, the consumer is responsible for updating this number after updating its own data store.",
+          "type": "number",
+          "default": "0"
+        },
+        {
+          "name": "noPaddingFooter",
+          "attribute": "no-padding-footer",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "rootPath",
+          "type": "string"
+        },
+        {
+          "name": "importPath",
+          "type": "string"
+        },
+        {
+          "name": "root",
+          "type": "HTMLElement | StampedTemplate | ShadowRoot | null"
+        },
+        {
+          "name": "$",
+          "type": "{ [key: string]: Element; }"
+        },
+        {
+          "name": "PROPERTY_EFFECT_TYPES"
+        }
+      ],
+      "events": [
+        {
+          "name": "d2l-filter-dropdown-cleared",
+          "description": "Dispatched when the clear button is pressed to clear all filters"
+        },
+        {
+          "name": "d2l-filter-dropdown-close",
+          "description": "Dispatched when the filter dropdown is closed"
+        }
+      ],
+      "slots": [
+        {
+          "name": "",
+          "description": "Contents of the dropdown, including filter categories and options"
+        },
+        {
+          "name": "footer",
+          "description": "Dropdown footer contents"
+        }
+      ]
+    },
+    {
+      "name": "d2l-search-facets-grouping",
+      "path": "./components/d2l-search-facets/d2l-search-facets-grouping.js",
+      "description": "A grouping of search facet options that keeps tracks of selected options",
+      "attributes": [
+        {
+          "name": "has-more",
+          "description": "Indicates whether this grouping has more options to be added later. Controls\nthe visibility of the 'More' button",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "text",
+          "description": "The name of the grouping",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "value",
+          "description": "The value of the grouping name",
+          "type": "string",
+          "default": "\"\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "hasMore",
+          "attribute": "has-more",
+          "description": "Indicates whether this grouping has more options to be added later. Controls\nthe visibility of the 'More' button",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "text",
+          "attribute": "text",
+          "description": "The name of the grouping",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "value",
+          "attribute": "value",
+          "description": "The value of the grouping name",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "rootPath",
+          "type": "string"
+        },
+        {
+          "name": "importPath",
+          "type": "string"
+        },
+        {
+          "name": "root",
+          "type": "HTMLElement | StampedTemplate | ShadowRoot | null"
+        },
+        {
+          "name": "$",
+          "type": "{ [key: string]: Element; }"
+        },
+        {
+          "name": "PROPERTY_EFFECT_TYPES"
+        }
+      ],
+      "events": [
+        {
+          "name": "d2l-search-facets-grouping-change",
+          "description": "Dispatched when the search group changes"
+        },
+        {
+          "name": "d2l-search-facets-grouping-has-more",
+          "description": "Dispatched when the more button is clicked"
+        }
+      ],
+      "slots": [
+        {
+          "name": "",
+          "description": "Contains the search facets in the group"
+        }
+      ]
+    },
+    {
+      "name": "d2l-search-facets-option",
+      "path": "./components/d2l-search-facets/d2l-search-facets-option.js",
+      "description": "Search facet option, with a count to display the number of results",
+      "attributes": [
+        {
+          "name": "checked",
+          "description": "Whether the option is selected or not. This property matches the value of\nthe d2l-input-checkbox",
+          "type": "boolean"
+        },
+        {
+          "name": "count",
+          "description": "The number of search results for this option",
+          "type": "number"
+        },
+        {
+          "name": "disabled",
+          "description": "Whether this option should be disabled",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "text",
+          "description": "The text for this option",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "value",
+          "description": "The value of this option",
+          "type": "string",
+          "default": "\"\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "checked",
+          "attribute": "checked",
+          "description": "Whether the option is selected or not. This property matches the value of\nthe d2l-input-checkbox",
+          "type": "boolean"
+        },
+        {
+          "name": "count",
+          "attribute": "count",
+          "description": "The number of search results for this option",
+          "type": "number"
+        },
+        {
+          "name": "disabled",
+          "attribute": "disabled",
+          "description": "Whether this option should be disabled",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "text",
+          "attribute": "text",
+          "description": "The text for this option",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "value",
+          "attribute": "value",
+          "description": "The value of this option",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "rootPath",
+          "type": "string"
+        },
+        {
+          "name": "importPath",
+          "type": "string"
+        },
+        {
+          "name": "root",
+          "type": "HTMLElement | StampedTemplate | ShadowRoot | null"
+        },
+        {
+          "name": "$",
+          "type": "{ [key: string]: Element; }"
+        },
+        {
+          "name": "PROPERTY_EFFECT_TYPES"
+        }
+      ],
+      "events": [
+        {
+          "name": "d2l-search-facets-option-change",
+          "description": "Dispatched when the checked value of an option changes"
+        }
+      ]
+    },
+    {
+      "name": "d2l-search-facets",
+      "path": "./components/d2l-search-facets/d2l-search-facets.js",
+      "description": "Polymer-based web component for D2L search facets.",
+      "properties": [
+        {
+          "name": "rootPath",
+          "type": "string"
+        },
+        {
+          "name": "importPath",
+          "type": "string"
+        },
+        {
+          "name": "root",
+          "type": "HTMLElement | StampedTemplate | ShadowRoot | null"
+        },
+        {
+          "name": "$",
+          "type": "{ [key: string]: Element; }"
+        },
+        {
+          "name": "PROPERTY_EFFECT_TYPES"
+        }
+      ],
+      "events": [
+        {
+          "name": "d2l-search-facets-change",
+          "description": "Dispatched when the search facets group changes"
+        }
+      ]
+    },
+    {
+      "name": "d2l-search-results-count",
+      "path": "./components/d2l-search-results-count/d2l-search-results-count.js",
+      "description": "`<d2l-search-results-count>`\nPolymer-based web component for D2L search result",
+      "attributes": [
+        {
+          "name": "range-start",
+          "description": "Range start",
+          "type": "number"
+        },
+        {
+          "name": "range-end",
+          "description": "Range end",
+          "type": "number"
+        },
+        {
+          "name": "total-count",
+          "description": "Total count",
+          "type": "number",
+          "default": "0"
+        },
+        {
+          "name": "query",
+          "description": "Search query",
+          "type": "string",
+          "default": "\"\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "rangeStart",
+          "attribute": "range-start",
+          "description": "Range start",
+          "type": "number"
+        },
+        {
+          "name": "rangeEnd",
+          "attribute": "range-end",
+          "description": "Range end",
+          "type": "number"
+        },
+        {
+          "name": "totalCount",
+          "attribute": "total-count",
+          "description": "Total count",
+          "type": "number",
+          "default": "0"
+        },
+        {
+          "name": "query",
+          "attribute": "query",
+          "description": "Search query",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "rootPath",
+          "type": "string"
+        },
+        {
+          "name": "importPath",
+          "type": "string"
+        },
+        {
+          "name": "root",
+          "type": "HTMLElement | StampedTemplate | ShadowRoot | null"
+        },
+        {
+          "name": "$",
+          "type": "{ [key: string]: Element; }"
+        },
+        {
+          "name": "PROPERTY_EFFECT_TYPES"
+        }
+      ]
+    },
+    {
+      "name": "d2l-sort-by-dropdown-option",
+      "path": "./components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js",
+      "description": "A dropdown option menu item component."
+    },
+    {
+      "name": "d2l-sort-by-dropdown",
+      "path": "./components/d2l-sort-by-dropdown/d2l-sort-by-dropdown.js",
+      "description": "Polymer-based web component for D2L sort by dropdown component",
+      "attributes": [
+        {
+          "name": "disabled",
+          "description": "Whether this dropdown should be disabled",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "compact",
+          "description": "Indicates whether the dropdown is in compact mode or not. The selection text\nwill not be visible when compact is true",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "align",
+          "description": "Alignment of dropdown menu",
+          "type": "string",
+          "default": "\"start\""
+        },
+        {
+          "name": "label",
+          "description": "Label for the dropdown-menu",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "value",
+          "description": "The value of the currently selected option",
+          "type": "string"
+        }
+      ],
+      "properties": [
+        {
+          "name": "disabled",
+          "attribute": "disabled",
+          "description": "Whether this dropdown should be disabled",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "compact",
+          "attribute": "compact",
+          "description": "Indicates whether the dropdown is in compact mode or not. The selection text\nwill not be visible when compact is true",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "align",
+          "attribute": "align",
+          "description": "Alignment of dropdown menu",
+          "type": "string",
+          "default": "\"start\""
+        },
+        {
+          "name": "label",
+          "attribute": "label",
+          "description": "Label for the dropdown-menu",
+          "type": "string",
+          "default": "\"\""
+        },
+        {
+          "name": "value",
+          "attribute": "value",
+          "description": "The value of the currently selected option",
+          "type": "string"
+        },
+        {
+          "name": "rootPath",
+          "type": "string"
+        },
+        {
+          "name": "importPath",
+          "type": "string"
+        },
+        {
+          "name": "root",
+          "type": "HTMLElement | StampedTemplate | ShadowRoot | null"
+        },
+        {
+          "name": "$",
+          "type": "{ [key: string]: Element; }"
+        },
+        {
+          "name": "PROPERTY_EFFECT_TYPES"
+        }
+      ],
+      "events": [
+        {
+          "name": "d2l-sort-by-dropdown-change",
+          "description": "Dispatched when option is selected"
+        }
+      ],
+      "slots": [
+        {
+          "name": "",
+          "description": "Contains the dropdown options (e.g., d2l-sort-by-dropdown-options)"
+        }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "name": "d2l-facet-filter-sort",
   "scripts": {
+    "analyze": "wca analyze components/**/*.js --format json --outFile custom-elements.json",
     "lint": "npm run lint:wc && npm run lint:js",
     "lint:js": "eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html",
     "lint:wc": "polymer lint -i \"./*\" \"test\" \"demo\" \"components\"",
@@ -26,7 +27,8 @@
     "frau-ci": "^1.33.2",
     "polymer-cli": "^1.9.5",
     "sauce-connect-launcher": "^1.2.4",
-    "wct-browser-legacy": "^1.0.1"
+    "wct-browser-legacy": "^1.0.1",
+    "web-component-analyzer": "^1"
   },
   "version": "3.4.0",
   "resolutions": {


### PR DESCRIPTION
This PR adds web components analyzer to generate custom-elements.json and adds more jsdoc comments throughout the components.
I did add custom-elements.json into source control since this isn't published to npm so I couldn't do what was done in core. It would be great to have this more automated so if anyone has suggestions there, that would be awesome.