### PR TITLE
Adamsk34/accessible applied filters

### DIFF
--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -3,6 +3,7 @@ import { LocalizeStaticMixin } from '@brightspace-ui/core/mixins/localize-static
 
 import '@brightspace-ui-labs/multi-select/multi-select-list';
 import '@brightspace-ui-labs/multi-select/multi-select-list-item';
+import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { getComposedChildren } from '@brightspace-ui/core/helpers/dom';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
@@ -130,6 +131,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 	}
 
 	_multiSelectItemDeleted(entry) {
+		announce('filter ' + entry.text + ' removed');
 		entry.deselect();
 	}
 

--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -216,6 +216,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 		const filters = this._selectedEntries && this._selectedEntries.length > 0 ?
 			html`<d2l-labs-multi-select-list
 				collapsable
+				aria-labelledby="d2l-applied-filters-label"
 			>
 				${(this._selectedEntries || []).map((x, index) => html`
 					<d2l-labs-multi-select-list-item
@@ -231,7 +232,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 
 		return html`
 			<div class="d2l-applied-filters-wrapper">
-				<span class="d2l-applied-filters-applied-filters-label d2l-body-compact">${this.localize('appliedFilters')}</span>
+				<span id="d2l-applied-filters-label" class="d2l-applied-filters-applied-filters-label d2l-body-compact">${this.localize('appliedFilters')}</span>
 				${filters}
 			</div>
 		`;

--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -75,7 +75,8 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 			},
 			'en': {
 				appliedFilters: 'Applied Filters:',
-				noActiveFilters: 'No active filters'
+				noActiveFilters: 'No active filters',
+				filterRemoved: 'Filter {filterText} removed'
 			},
 			'es': {
 			},
@@ -131,7 +132,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 	}
 
 	_multiSelectItemDeleted(entry) {
-		announce(`filter ${entry.text} removed`);
+		announce(this.localize('filterRemoved', 'filterText', entry.text));
 		entry.deselect();
 	}
 

--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -223,6 +223,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 						text="${x.text}"
 						deletable
 						index="${index}"
+						role="listitem"
 						@d2l-labs-multi-select-list-item-deleted="${() => this._multiSelectItemDeleted(x)}"
 					>
 					</d2l-labs-multi-select-list-item>

--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -131,7 +131,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 	}
 
 	_multiSelectItemDeleted(entry) {
-		announce('filter ' + entry.text + ' removed');
+		announce(`filter ${entry.text} removed`);
 		entry.deselect();
 	}
 

--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -225,7 +225,6 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 						text="${x.text}"
 						deletable
 						index="${index}"
-						role="listitem"
 						@d2l-labs-multi-select-list-item-deleted="${() => this._multiSelectItemDeleted(x)}"
 					>
 					</d2l-labs-multi-select-list-item>


### PR DESCRIPTION
This relates to the issue:
https://rally1.rallydev.com/#/detail/userstory/395253921988?fdp=true

Solves these 2 acceptance criteria:
> - It announces "Applied Filters" when focus enters the component
> - It announces when a filter was cleared when a filter is removed from the list via user interaction (eg. clicking on the "close" button, using the "delete" key, etc)

~Also solves a problem where sometimes NVDA would say "text frame" and nothing else when selecting a filter~ (change removed)