### PR TITLE
DE39995 - Fix d2l-filter-dropdown-category-selected event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+cache:
+  npm: false
 language: node_js
 node_js: node
 addons:

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
@@ -165,6 +165,9 @@ class FilterDropdownCategory extends LocalizeStaticMixin(TabPanelMixin(LitElemen
 			this.selected = !this.selected;
 			this.__onSelect(e);
 		});
+		this.addEventListener('d2l-tab-panel-selected', () => {
+			this._dispatchSelected();
+		});
 	}
 
 	_onSlotChange() {
@@ -186,7 +189,6 @@ class FilterDropdownCategory extends LocalizeStaticMixin(TabPanelMixin(LitElemen
 	}
 
 	_dispatchSelected() {
-		super._dispatchSelected();
 		this.dispatchEvent(new CustomEvent('d2l-filter-dropdown-category-selected', {
 			detail: {
 				categoryKey: this.key


### PR DESCRIPTION
The `d2l-filter-dropdown-category-selected` event has not been firing since `_dispatchSelected` was accidentally removed from the `d2l-tab-panel-mixin`.  This feels better than relying on a private function from the mixin anyways.

Tests would have caught this, but because we use npm caches it did not.  I've turned those caches off.