### PR TITLE
3.4.0 - DE39995 - Fix d2l-filter-dropdown-category-selected event

### DIFF
--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
@@ -142,6 +142,9 @@ class FilterDropdownCategory extends LocalizeStaticMixin(TabPanelMixin(LitElemen
 			this.selected = !this.selected;
 			this.__onSelect(e);
 		});
+		this.addEventListener('d2l-tab-panel-selected', () => {
+			this._dispatchSelected();
+		});
 	}
 
 	_onSlotChange() {
@@ -163,7 +166,6 @@ class FilterDropdownCategory extends LocalizeStaticMixin(TabPanelMixin(LitElemen
 	}
 
 	_dispatchSelected() {
-		super._dispatchSelected();
 		this.dispatchEvent(new CustomEvent('d2l-filter-dropdown-category-selected', {
 			detail: {
 				categoryKey: this.key


### PR DESCRIPTION
Same as https://github.com/BrightspaceUI/facet-filter-sort/pull/55 against version `3.4.0`, which is the version Portfolio needs for backporting.  Will create a special release they can point to.