### PR TITLE
DE40159 - Keep the searchValue property in sync with the input's value

### DIFF
--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
@@ -31,7 +31,7 @@ class FilterDropdownCategory extends LocalizeStaticMixin(TabPanelMixin(LitElemen
 			 */
 			key: { type: String },
 			/**
-			 * Sets the value in the search input, useful if setting up the filter in a default state
+			 * Sets the value in the search input
 			 */
 			searchValue: { type: String, attribute: 'search-value' },
 			/**
@@ -213,6 +213,8 @@ class FilterDropdownCategory extends LocalizeStaticMixin(TabPanelMixin(LitElemen
 
 	_handleSearchChange(e) {
 		e.stopPropagation();
+
+		this.searchValue = e.detail.value;
 		this.dispatchEvent(new CustomEvent('d2l-filter-dropdown-category-searched', {
 			detail: {
 				categoryKey: this.key,

--- a/test/d2l-filter-dropdown/d2l-filter-dropdown-category.html
+++ b/test/d2l-filter-dropdown/d2l-filter-dropdown-category.html
@@ -82,14 +82,16 @@
 						done();
 					});
 				});
-				test('searching triggers the d2l-filter-dropdown-category-searched event', function(done) {
+				test('searching triggers the d2l-filter-dropdown-category-searched event and updates the searchValue property', function(done) {
 					container.addEventListener('d2l-filter-dropdown-category-searched', function(e) {
 						assert.equal(e.detail.categoryKey, '1');
 						assert.equal(e.detail.value, 'test');
+						assert.equal(categories[0].searchValue, 'test');
 						done();
 					});
-					categories[0].searchValue = 'test';
+
 					categories[0].updateComplete.then(function() {
+						categories[0].shadowRoot.querySelector('d2l-input-search').value = 'test';
 						categories[0].shadowRoot.querySelector('d2l-input-search').search();
 					});
 				});


### PR DESCRIPTION
This is needed in My Courses to allow me to be able to clear the filter's value on overlay closed, and for a defect fix in Quick Eval to be able to grab the search value and re-filter the options when the filter's data objects are cleared and recalculated by the HM calls (which happens on option selection).