### PR TITLE
fix: setting a label on the search input

### DIFF
--- a/components/filter-dropdown/filter-dropdown-category.js
+++ b/components/filter-dropdown/filter-dropdown-category.js
@@ -192,6 +192,7 @@ class LabsFilterDropdownCategory extends LocalizeStaticMixin(TabPanelMixin(LitEl
 		return html`
 			<div class="d2l-labs-filter-dropdown-page-search" ?hidden="${this.disableSearch}">
 				<d2l-input-search @d2l-input-search-searched="${this._handleSearchChange}"
+					label="${this.localize('searchBy', 'category', this.categoryText)}"
 					placeholder="${this.localize('searchBy', 'category', this.categoryText)}"
 					value="${ifDefined(this.searchValue)}">
 				</d2l-input-search>


### PR DESCRIPTION
This is now throwing missing label exceptions and is breaking Quick Eval's tests.