### PR TITLE
feat: filter-dropdown-category: no longer listen for d2l-tab-panel-selected event

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ Note that for the header and opener text overrides, if the terms are to reflect 
 
 - `d2l-labs-filter-dropdown-close`: Fired when the filter dropdown is closed.
 - `d2l-labs-filter-dropdown-cleared`: Fired when the clear button or the clear filters button is pressed to clear all filters.
+- `d2l-labs-filter-dropdown-category-selected`: Fired when a filter tab is selected.
 
 `d2l-labs-filter-dropdown-category`:
 
-- `d2l-labs-filter-dropdown-category-selected`: Fired when a filter tab is selected.
 - `d2l-labs-filter-dropdown-category-searched`: Fired when a filter category is searched.
 - `d2l-labs-filter-dropdown-option-change`: Fired when a filter option is selected.
 

--- a/components/filter-dropdown/filter-dropdown-category.js
+++ b/components/filter-dropdown/filter-dropdown-category.js
@@ -102,10 +102,6 @@ class LabsFilterDropdownCategory extends FilterLocalizeMixin(TabPanelMixin(LitEl
 			this.selected = !this.selected;
 			this.__onSelect(e);
 		});
-
-		this.addEventListener('d2l-tab-panel-selected', () => {
-			this._dispatchSelected();
-		});
 	}
 
 	render() {
@@ -121,17 +117,6 @@ class LabsFilterDropdownCategory extends FilterLocalizeMixin(TabPanelMixin(LitEl
 				<slot @slotchange="${this._onSlotChange}"></slot>
 			</d2l-menu>
 		`;
-	}
-
-	_dispatchSelected() {
-		// Event propagation of d2l-tab-panel-selected stopped in d2l-labs-filter-dropdown
-		this.dispatchEvent(new CustomEvent('d2l-labs-filter-dropdown-category-selected', {
-			detail: {
-				categoryKey: this.key
-			},
-			bubbles: true,
-			composed: true
-		}));
 	}
 
 	_handleMenuItemChange(e) {

--- a/components/filter-dropdown/filter-dropdown.js
+++ b/components/filter-dropdown/filter-dropdown.js
@@ -133,7 +133,7 @@ class D2LLabsFilterDropdown extends mixinBehaviors([LocalizeBehavior], PolymerEl
 					</div>
 					<d2l-tabs>
 						<template is="dom-repeat" items="[[_tabInfos]]" as="tab">
-							<d2l-tab id="[[tab.key]]" text="[[tab.text]]" slot="tabs" selected$="[[tab.selected]]"></d2l-tab>
+							<d2l-tab id="[[tab.key]]" text="[[tab.text]]" slot="tabs" selected$="[[tab.selected]]" on-d2l-tab-selected="_dispatchSelected"></d2l-tab>
 						</template>
 						<slot on-slotchange="_handleCategoriesSlotChange" slot="panels"></slot>
 					</d2l-tabs>
@@ -145,7 +145,6 @@ class D2LLabsFilterDropdown extends mixinBehaviors([LocalizeBehavior], PolymerEl
 
 	attached() {
 		this.addEventListener('d2l-dropdown-close', this._handleDropdownClose);
-		this.addEventListener('d2l-tab-panel-selected', this._stopTabPanelSelectedEvent);
 	}
 
 	clearFilters() {
@@ -166,7 +165,6 @@ class D2LLabsFilterDropdown extends mixinBehaviors([LocalizeBehavior], PolymerEl
 
 	detached() {
 		this.removeEventListener('d2l-dropdown-close', this._handleDropdownClose);
-		this.removeEventListener('d2l-tab-panel-selected', this._stopTabPanelSelectedEvent);
 
 		const categories = this.querySelectorAll('d2l-labs-filter-dropdown-category');
 		categories.forEach(cat => {
@@ -179,6 +177,16 @@ class D2LLabsFilterDropdown extends mixinBehaviors([LocalizeBehavior], PolymerEl
 
 	focus() {
 		this.shadowRoot.querySelector('d2l-dropdown-button-subtle').focus();
+	}
+
+	_dispatchSelected(e) {
+		this.dispatchEvent(new CustomEvent('d2l-labs-filter-dropdown-category-selected', {
+			detail: {
+				categoryKey: e.target.id
+			},
+			bubbles: true,
+			composed: true
+		}));
 	}
 
 	_getFooterSlotValue(hasFooter) {
@@ -250,11 +258,6 @@ class D2LLabsFilterDropdown extends mixinBehaviors([LocalizeBehavior], PolymerEl
 	_localizeOrAlt(altText, ...args) {
 		if (!this.localize || !this.resources) return;
 		return altText ? altText : this.localize(...args);
-	}
-
-	// Must be done here (instead of d2l-labs-filter-dropdown-category) as the d2l-dropdown-tabs component needs to receive it
-	_stopTabPanelSelectedEvent(e) {
-		e.stopPropagation();
 	}
 }
 

--- a/test/filter-dropdown/filter-dropdown-category.test.js
+++ b/test/filter-dropdown/filter-dropdown-category.test.js
@@ -1,12 +1,12 @@
 
-import '@brightspace-ui/core/components/tabs/tabs.js';
+import '../../components/filter-dropdown/filter-dropdown.js';
 import '../../components/filter-dropdown/filter-dropdown-category.js';
 import '../../components/filter-dropdown/filter-dropdown-option.js';
 import { expect, fixture, html, oneEvent } from '@brightspace-ui/testing';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
 const basic = html`
-	<d2l-tabs>
+	<d2l-labs-filter-dropdown>
 		<d2l-labs-filter-dropdown-category key="1" category-text="Category 1" selected-option-count="3">
 			<d2l-labs-filter-dropdown-option selected text="Option 1 - 1" value="1"></d2l-labs-filter-dropdown-option>
 			<d2l-labs-filter-dropdown-option text="Option 1 - 2" value="2"></d2l-labs-filter-dropdown-option>
@@ -20,7 +20,7 @@ const basic = html`
 			<d2l-labs-filter-dropdown-option text="Option 2 - 2" value="2"></d2l-labs-filter-dropdown-option>
 			<d2l-labs-filter-dropdown-option text="Option 2 - 3" value="3"></d2l-labs-filter-dropdown-option>
 		</d2l-labs-filter-dropdown-category>
-	</d2l-tabs>`;
+	</d2l-labs-filter-dropdown>`;
 
 describe('d2l-labs-filter-dropdown-category', () => {
 	let container;
@@ -87,7 +87,8 @@ describe('d2l-labs-filter-dropdown-category', () => {
 		expect(categories[0].searchValue).to.equal('test');
 	});
 	it('changing the category tab triggers the d2l-labs-filter-dropdown-category-selected event', async() => {
-		setTimeout(() => categories[1].selected = true);
+		const tabs = container.shadowRoot.querySelectorAll('d2l-tab');
+		setTimeout(() => tabs[1].selected = true);
 		const e = await oneEvent(container, 'd2l-labs-filter-dropdown-category-selected');
 		expect(e.detail.categoryKey).to.equal('2');
 	});


### PR DESCRIPTION
[GAUD-9869](https://desire2learn.atlassian.net/browse/GAUD-9869)

This switch is a bit more complex since it's using tabPanelMixin. I'll leave comments.

We are deprecating `d2l-tab-panel-selected` event so this switches to listening for `d2l-tab-selected` instead.

[GAUD-9869]: https://desire2learn.atlassian.net/browse/GAUD-9869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ