### PR TITLE
Check the new tabs structure flag to determine which API to use

### DIFF
--- a/components/filter-dropdown/filter-dropdown.js
+++ b/components/filter-dropdown/filter-dropdown.js
@@ -2,9 +2,9 @@ import '@brightspace-ui/core/components/button/button-subtle.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/dropdown/dropdown-button-subtle.js';
 import '@brightspace-ui/core/components/dropdown/dropdown-tabs.js';
-import '@brightspace-ui/core/components/tabs/tabs.js';
 import '@brightspace-ui/core/components/tabs/tab.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { getUseNewTabsStructureFlag } from '@brightspace-ui/core/components/tabs/tabs.js';
 import { LocalizeBehavior } from '../localize-behavior.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
@@ -211,12 +211,17 @@ class D2LLabsFilterDropdown extends mixinBehaviors([LocalizeBehavior], PolymerEl
 
 		if (!tabsContainer || !categories || categories.length === 0) return;
 
+		// Clean up when GAUD-8299-core-tabs-use-new-structure flag is removed
+		const useNewTabsStructureFlag = getUseNewTabsStructureFlag();
+
 		// Build tabInfos which is used to render d2l-tab components
 		const tabInfos = [];
 		categories.forEach((category, index) => {
 			const key = category.getAttribute('key') || `category-${index}`;
 			const text = category.getAttribute('text');
-			const isSelected = category.hasAttribute('selected');
+
+			// Clean up when GAUD-8299-core-tabs-use-new-structure flag is removed
+			const isSelected = useNewTabsStructureFlag ? category._selected : category.hasAttribute('selected');
 
 			category.setAttribute('labelled-by', key);
 			tabInfos.push({ key, text, selected: isSelected });
@@ -224,7 +229,10 @@ class D2LLabsFilterDropdown extends mixinBehaviors([LocalizeBehavior], PolymerEl
 			if (!category.__tabInfoObserver) {
 				category.__tabInfoObserver = new MutationObserver(() => {
 					const newText = category.getAttribute('text');
-					const newSelected = category.hasAttribute('selected');
+
+					// Clean up when GAUD-8299-core-tabs-use-new-structure flag is removed
+					const newSelected = useNewTabsStructureFlag ? category._selected : category.hasAttribute('selected');
+
 					this._tabInfos = this._tabInfos.map(info => {
 						return info.key === key
 							? { ...info, text: newText, selected: newSelected }


### PR DESCRIPTION
[GAUD-10150](https://desire2learn.atlassian.net/browse/GAUD-10150)

This PR updates `d2l-labs-filter-dropdown` to check the `GAUD-8299-core-tabs-use-new-structure` in order to use the correct API to check the panel's selected state. This is necessary because the selected state of the panel is internal with the new API.

[GAUD-10150]: https://desire2learn.atlassian.net/browse/GAUD-10150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ